### PR TITLE
Bugfix: when shrinking DateTimeOffset, only output zero offset if not al...

### DIFF
--- a/FsCheck/Arbitrary.fs
+++ b/FsCheck/Arbitrary.fs
@@ -546,7 +546,8 @@ module Arb =
                 seq {
                     for ts in shrinkTimeZone d.Offset ->
                         DateTimeOffset(d.DateTime, ts)
-                    yield DateTimeOffset(d.DateTime, TimeSpan.Zero)
+                    if d.Offset <> TimeSpan.Zero then
+                        yield DateTimeOffset(d.DateTime, TimeSpan.Zero)
                     for dt in shrink d.DateTime ->
                         DateTimeOffset(dt, TimeSpan.Zero) }
             fromGenShrink (genDate, shrink)


### PR DESCRIPTION
...ready zero

This was making DateTimeOffset shrinking not terminate! :-(
