### PR TITLE
Check null CultureInfo when shrinking.

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -705,7 +705,7 @@ module Arb =
         static member Culture() =
             let genCulture = Gen.elements (CultureInfo.GetCultures (CultureTypes.NeutralCultures ||| CultureTypes.SpecificCultures))
             let shrinkCulture =
-                Seq.unfold <| fun c -> if c = CultureInfo.InvariantCulture
+                Seq.unfold <| fun c -> if c = null || c = CultureInfo.InvariantCulture
                                             then None
                                             else Some (c.Parent, c.Parent)
             fromGenShrink (genCulture, shrinkCulture)


### PR DESCRIPTION
[Mono sometimes returns a null parent culture](https://github.com/mono/mono/blob/master/mcs/class/corlib/System.Globalization/CultureInfo.cs#L303)

[Microsoft always returns a non-null CultureInfo](http://referencesource.microsoft.com/#mscorlib/system/globalization/cultureinfo.cs#865)

https://github.com/fsharp/FsCheck/issues/37#issuecomment-46102440
