### PR TITLE
Make it possible to tell nunit to be quiet on success

### DIFF
--- a/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
+++ b/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
@@ -26,4 +26,7 @@
     [<Property>]
     let product (x:int, y:int) =
         (x > 0 && y > 0) ==> (x*y > 0)        
-    
+
+    [<Property(QuietOnSuccess = true)>]
+    let noOutputOnSuccess (x:char) = 
+        List.rev [x] = [x]

--- a/src/FsCheck.NUnit.Addin/FsCheckTestMethod.fs
+++ b/src/FsCheck.NUnit.Addin/FsCheckTestMethod.fs
@@ -66,13 +66,22 @@ type FsCheckTestMethod(mi : MethodInfo) =
         let attr = x.getFsCheckPropertyAttribute()
         let testRunner = { new IRunner with
                 member x.OnStartFixture t = ()
-                member x.OnArguments (ntest, args, every) = Console.Write(every ntest args)
+                member x.OnArguments (ntest, args, every) =
+                    let argsForOutput = every ntest args
+                    // Only write the args if there's something to write.
+                    // Although it may seem harmless to write an empty string, writing anything at this stage seems to
+                    // trigger NUnit's formatting system, so that it adds a 'header' for the test in the output. That
+                    // doesn't look pretty in the cases where it turns out that there's truly nothing to write (e.g.
+                    // when QuietOnSuccess is true, and the Property passed.
+                    if not (String.IsNullOrWhiteSpace argsForOutput) then
+                        Console.Write(argsForOutput)
                 member x.OnShrink(args, everyShrink) = Console.Write(everyShrink args)
                 member x.OnFinished(name, fsCheckResult) = 
                     let message = Runner.onFinishedToString name fsCheckResult
                     match fsCheckResult with
                     | TestResult.True _ ->                        
-                        Console.WriteLine(message)
+                        if not attr.QuietOnSuccess then
+                            Console.WriteLine(message)
                     | _ ->                        
                         Console.WriteLine(message)
                         Assert.Fail(message) //TODO: find better way to tell NUnit about error. Now AssertionException is wrapped into TargetInvocationException

--- a/src/FsCheck.NUnit/FsCheckPropertyAttribute.fs
+++ b/src/FsCheck.NUnit/FsCheckPropertyAttribute.fs
@@ -14,6 +14,7 @@ type PropertyAttribute() =
     let mutable startSize = Config.Default.StartSize
     let mutable endSize = Config.Default.EndSize
     let mutable verbose = false
+    let mutable quietOnSuccess = false
     let mutable arbitrary = Config.Default.Arbitrary |> List.toArray
 
     ///The maximum number of tests that are run.
@@ -30,4 +31,11 @@ type PropertyAttribute() =
     ///are merged in back to front order i.e. instances for the same generated type 
     //at the front of the array will override those at the back.
     member x.Arbitrary with get() = arbitrary and set(v) = arbitrary <- v
+    ///If set, suppresses the output from the test if the test is successful. This can be useful when running tests
+    ///with TestDriven.net, because TestDriven.net pops up the Output window in Visual Studio if a test fails; thus,
+    ///when conditioned to that behaviour, it's always a bit jarring to receive output from passing tests.
+    ///The default is false, which means that FsCheck will also output test results on success, but if set to true,
+    ///FsCheck will suppress output in the case of a passing test. This setting doesn't affect the behaviour in case of
+    ///test failures.
+    member x.QuietOnSuccess with get() = quietOnSuccess and set(v) = quietOnSuccess <- v
 


### PR DESCRIPTION
As requested by @kurtschelfthout in #64, here's the same behaviour, but for NUnit instead of xUnit.net.
