### PR TITLE
Typo in ToString method of the Dec class

### DIFF
--- a/docs/csharp/StatefulTesting.cs
+++ b/docs/csharp/StatefulTesting.cs
@@ -71,7 +71,7 @@ namespace CSharp.DocSnippets {
             }
 
             public override string ToString() {
-                return "inc";
+                return "dec";
             }
         }
     }


### PR DESCRIPTION
The ToString was returning "inc" instead of "dec"