### PR TITLE
Workarounds for non portable code

### DIFF
--- a/docs/csharp/App.config
+++ b/docs/csharp/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
+  <startup> 
+      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
 </configuration>

--- a/docs/csharp/CSharp.DocSnippets.csproj
+++ b/docs/csharp/CSharp.DocSnippets.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>CSharp.DocSnippets</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,7 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/examples/FsCheck.CSharpExamples/FsCheck.CSharpExamples.csproj
+++ b/examples/FsCheck.CSharpExamples/FsCheck.CSharpExamples.csproj
@@ -31,6 +31,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,7 +55,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -90,7 +93,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/examples/FsCheck.CSharpExamples/app.config
+++ b/examples/FsCheck.CSharpExamples/app.config
@@ -3,16 +3,4 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.3.13283" newVersion="2.6.3.13283" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/examples/FsCheck.Examples/App.config
+++ b/examples/FsCheck.Examples/App.config
@@ -3,14 +3,4 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.3.0.0" />
-        <bindingRedirect oldVersion="2.3.5.0" newVersion="4.3.0.0" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.3.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/examples/FsCheck.Examples/FsCheck.Examples.fsproj
+++ b/examples/FsCheck.Examples/FsCheck.Examples.fsproj
@@ -15,6 +15,7 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -51,9 +52,7 @@
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
     <Compile Include="Examples.fs" />
-    <None Include="App.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/examples/FsCheck.MsTest.Examples/App.config
+++ b/examples/FsCheck.MsTest.Examples/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/examples/FsCheck.MsTest.Examples/FsCheck.MsTest.Examples.csproj
+++ b/examples/FsCheck.MsTest.Examples/FsCheck.MsTest.Examples.csproj
@@ -17,6 +17,7 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,7 +37,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
@@ -48,6 +51,7 @@
     <Compile Include="DocGen.cs" />
     <Compile Include="DocTest.cs" />
     <Compile Include="SampleTests.cs" />
+    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/examples/FsCheck.NUnit.CSharpExamples/App.config
+++ b/examples/FsCheck.NUnit.CSharpExamples/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/examples/FsCheck.NUnit.CSharpExamples/FsCheck.NUnit.CSharpExamples.csproj
+++ b/examples/FsCheck.NUnit.CSharpExamples/FsCheck.NUnit.CSharpExamples.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,7 +35,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.core.interfaces">
       <HintPath>..\..\packages\NUnit.Runners\tools\lib\nunit.core.interfaces.dll</HintPath>
     </Reference>
@@ -51,6 +54,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/FsCheck.NUnit.Examples/App.config
+++ b/examples/FsCheck.NUnit.Examples/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/examples/FsCheck.NUnit.Examples/FsCheck.NUnit.Examples.fsproj
+++ b/examples/FsCheck.NUnit.Examples/FsCheck.NUnit.Examples.fsproj
@@ -15,6 +15,7 @@
     </TargetFrameworkProfile>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,6 +57,7 @@
     <Compile Include="FsCheckAddin.fs" />
     <Compile Include="PropertyExamples.fs" />
     <None Include="paket.references" />
+    <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/examples/FsCheck.XUnit.CSharpExamples/App.config
+++ b/examples/FsCheck.XUnit.CSharpExamples/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/examples/FsCheck.XUnit.CSharpExamples/FsCheck.XUnit.CSharpExamples.csproj
+++ b/examples/FsCheck.XUnit.CSharpExamples/FsCheck.XUnit.CSharpExamples.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +50,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FsCheck.NUnit.Addin/FsCheck.NUnit.Addin.fsproj
+++ b/src/FsCheck.NUnit.Addin/FsCheck.NUnit.Addin.fsproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="nunit.core">

--- a/src/FsCheck.NUnit/FsCheck.NUnit.fsproj
+++ b/src/FsCheck.NUnit/FsCheck.NUnit.fsproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
+++ b/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
@@ -63,7 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -754,7 +754,131 @@ module Arb =
             |> convert (fun x -> x :> IDictionary<_,_>) (fun x -> x :?> Dictionary<_,_>)
 
         static member Culture() =
-            let genCulture = Gen.elements (CultureInfo.GetCultures (CultureTypes.NeutralCultures ||| CultureTypes.SpecificCultures))
+            let names = [
+                "af"; "af-ZA";
+                "am"; "am-ET";
+                "ar"; "ar-AE"; "ar-BH"; "ar-DZ"; "ar-EG"; "ar-IQ"; "ar-JO"; "ar-KW"; "ar-LB"; "ar-LY"; "ar-MA"; "ar-OM"; "ar-QA"; "ar-SA"; "ar-SY"; "ar-TN"; "ar-YE"; "arn"; "arn-CL";
+                "as"; "as-IN";
+                "az"; "az-Cyrl"; "az-Cyrl-AZ"; "az-Latn"; "az-Latn-AZ";
+                "ba"; "ba-RU";
+                "be"; "be-BY";
+                "bg"; "bg-BG";
+                "bn"; "bn-BD"; "bn-IN";
+                "bo"; "bo-CN";
+                "br"; "br-FR";
+                "bs"; "bs-Cyrl"; "bs-Cyrl-BA"; "bs-Latn"; "bs-Latn-BA";
+                "ca"; "ca-ES";
+                "co"; "co-FR";
+                "cs"; "cs-CZ";
+                "cy"; "cy-GB";
+                "da"; "da-DK";
+                "de"; "de-AT"; "de-CH"; "de-DE"; "de-LI"; "de-LU";
+                "dsb"; "dsb-DE";
+                "dv"; "dv-MV";
+                "el"; "el-GR";
+                "en"; "en-029"; "en-AU"; "en-BZ"; "en-CA"; "en-GB"; "en-IE"; "en-IN"; "en-JM"; "en-MY"; "en-NZ"; "en-PH"; "en-SG"; "en-TT"; "en-US"; "en-ZA"; "en-ZW";
+                "es"; "es-AR"; "es-BO"; "es-CL"; "es-CO"; "es-CR"; "es-DO"; "es-EC"; "es-ES"; "es-GT"; "es-HN"; "es-MX"; "es-NI"; "es-PA"; "es-PE"; "es-PR"; "es-PY"; "es-SV"; "es-US"; "es-UY"; "es-VE";
+                "et"; "et-EE";
+                "eu"; "eu-ES";
+                "fa"; "fa-IR";
+                "fi"; "fi-FI"; "fil"; "fil-PH";
+                "fo"; "fo-FO";
+                "fr"; "fr-BE"; "fr-CA"; "fr-CH"; "fr-FR"; "fr-LU"; "fr-MC";
+                "fy"; "fy-NL";
+                "ga"; "ga-IE";
+                "gd"; "gd-GB";
+                "gl"; "gl-ES";
+                "gsw"; "gsw-FR";
+                "gu"; "gu-IN";
+                "ha"; "ha-Latn"; "ha-Latn-NG";
+                "he"; "he-IL";
+                "hi"; "hi-IN";
+                "hr"; "hr-BA"; "hr-HR";
+                "hsb"; "hsb-DE";
+                "hu"; "hu-HU";
+                "hy"; "hy-AM";
+                "id"; "id-ID";
+                "ig"; "ig-NG";
+                "ii"; "ii-CN";
+                "is"; "is-IS";
+                "it"; "it-CH"; "it-IT";
+                "iu"; "iu-Cans"; "iu-Cans-CA"; "iu-Latn"; "iu-Latn-CA";
+                "ja"; "ja-JP";
+                "ka"; "ka-GE";
+                "kk"; "kk-KZ";
+                "kl"; "kl-GL";
+                "km"; "km-KH";
+                "kn"; "kn-IN";
+                "ko"; "ko-KR"; "kok"; "kok-IN";
+                "ky"; "ky-KG";
+                "lb"; "lb-LU";
+                "lo"; "lo-LA";
+                "lt"; "lt-LT";
+                "lv"; "lv-LV";
+                "mi"; "mi-NZ";
+                "mk"; "mk-MK";
+                "ml"; "ml-IN";
+                "mn"; "mn-Cyrl"; "mn-MN"; "mn-Mong"; "mn-Mong-CN";
+                "moh"; "moh-CA";
+                "mr"; "mr-IN";
+                "ms"; "ms-BN"; "ms-MY";
+                "mt"; "mt-MT";
+                "nb"; "nb-NO";
+                "ne"; "ne-NP";
+                "nl"; "nl-BE"; "nl-NL";
+                "nn"; "nn-NO";
+                "no";
+                "nso"; "nso-ZA";
+                "oc"; "oc-FR";
+                "or"; "or-IN";
+                "pa"; "pa-IN";
+                "pl"; "pl-PL";
+                "prs"; "prs-AF";
+                "ps"; "ps-AF";
+                "pt"; "pt-BR"; "pt-PT";
+                "qut"; "qut-GT"; "quz"; "quz-BO"; "quz-EC"; "quz-PE";
+                "rm"; "rm-CH";
+                "ro"; "ro-RO";
+                "ru"; "ru-RU";
+                "rw"; "rw-RW";
+                "sa"; "sa-IN"; "sah"; "sah-RU";
+                "se"; "se-FI"; "se-NO"; "se-SE";
+                "si"; "si-LK";
+                "sk"; "sk-SK";
+                "sl"; "sl-SI";
+                "sma"; "sma-NO"; "sma-SE"; "smj"; "smj-NO"; "smj-SE"; "smn"; "smn-FI"; "sms"; "sms-FI";
+                "sq"; "sq-AL";
+                "sr"; "sr-Cyrl"; "sr-Cyrl-BA"; "sr-Cyrl-CS"; "sr-Cyrl-ME"; "sr-Cyrl-RS"; "sr-Latn"; "sr-Latn-BA"; "sr-Latn-CS"; "sr-Latn-ME"; "sr-Latn-RS";
+                "sv"; "sv-FI"; "sv-SE";
+                "sw"; "sw-KE";
+                "syr"; "syr-SY";
+                "ta"; "ta-IN";
+                "te"; "te-IN";
+                "tg"; "tg-Cyrl"; "tg-Cyrl-TJ";
+                "th"; "th-TH";
+                "tk"; "tk-TM";
+                "tn"; "tn-ZA";
+                "tr"; "tr-TR";
+                "tt"; "tt-RU";
+                "tzm"; "tzm-Latn"; "tzm-Latn-DZ";
+                "ug"; "ug-CN";
+                "uk"; "uk-UA";
+                "ur"; "ur-PK";
+                "uz"; "uz-Cyrl"; "uz-Cyrl-UZ"; "uz-Latn"; "uz-Latn-UZ";
+                "vi"; "vi-VN";
+                "wo"; "wo-SN";
+                "xh"; "xh-ZA";
+                "yo"; "yo-NG";
+                "zh"; "zh-CN"; "zh-HK"; "zh-Hans"; "zh-Hant"; "zh-MO"; "zh-SG"; "zh-TW";
+                "zu"; "zu-ZA";]
+            let cultures = 
+                names |> Seq.choose (fun name -> try Some (CultureInfo name) with _ -> None)
+                      |> Seq.append [ CultureInfo.InvariantCulture; 
+                                      CultureInfo.CurrentCulture; 
+                                      CultureInfo.CurrentUICulture; 
+                                      CultureInfo.DefaultThreadCurrentCulture;
+                                      CultureInfo.DefaultThreadCurrentUICulture; ]
+            let genCulture = Gen.elements cultures
             let shrinkCulture =
                 Seq.unfold <| fun c -> if c = null || c = CultureInfo.InvariantCulture || c.Parent = null
                                             then None

--- a/src/FsCheck/FsCheck.fsproj
+++ b/src/FsCheck/FsCheck.fsproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,9 +11,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Name>FsCheck</Name>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <TargetProfile>netcore</TargetProfile>
     <TargetFSharpCoreVersion>3.259.3.1</TargetFSharpCoreVersion>
@@ -40,8 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\FsCheck.XML</DocumentationFile>
-    <OtherFlags>
-    </OtherFlags>
+    <OtherFlags>--nooptimizationdata</OtherFlags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DocumentationFile>bin\Debug\FsCheck.XML</DocumentationFile>
@@ -50,21 +47,9 @@
     <DocumentationFile>bin\Release\FsCheck.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">12</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Common.fs" />
@@ -84,8 +69,6 @@
     <Compile Include="RunnerExtensions.fs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
     <Reference Include="FSharp.Core">
       <Name>FSharp.Core</Name>
       <AssemblyName>FSharp.Core.dll</AssemblyName>

--- a/src/FsCheck/FsCheck.fsproj
+++ b/src/FsCheck/FsCheck.fsproj
@@ -13,6 +13,9 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetProfile>netcore</TargetProfile>
+    <TargetFSharpCoreVersion>3.259.3.1</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,8 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Tailcalls>true</Tailcalls>
-    <OtherFlags>
-    </OtherFlags>
+    <OtherFlags>--nooptimizationdata</OtherFlags>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>
     </WarningsAsErrors>
@@ -84,11 +86,15 @@
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
+    <Reference Include="FSharp.Core">
+      <Name>FSharp.Core</Name>
+      <AssemblyName>FSharp.Core.dll</AssemblyName>
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 	     Other similar extension points exist, see Microsoft.Common.targets.

--- a/tests/FsCheck.Test/App.config
+++ b/tests/FsCheck.Test/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/FsCheck.Test/FsCheck.Test.fsproj
+++ b/tests/FsCheck.Test/FsCheck.Test.fsproj
@@ -13,6 +13,7 @@
     </TargetFrameworkProfile>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -58,6 +59,7 @@
     <Compile Include="Fluent.fs" />
     <None Include="Script.fsx" />
     <None Include="paket.references" />
+    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FsCheck.Xunit\FsCheck.Xunit.fsproj">


### PR DESCRIPTION
Implemented quick and dirty workarounds for `System.Console`, `CultureInfo.GetCultures` which can't be used in `Portable259`.
Adjusted `AutoGenerateBindingRedirects` and `Reference.Private (CopyLocal)` according to recommendations: [Notes and Guidance on FSharp.Core](https://fsharp.github.io/2015/04/18/fsharp-core-notes.html). 
Unfortunately compiler bug ([Inlining breaks PCL-defined methods in normal assemblies](http://visualfsharp.codeplex.com/workitem/144)) is presented in `divMod` and `divMod64` even when `--nooptimizationdata` is specified.
UPD: Re-read bug compiler bug description and it seems like `--nooptimizationdata` only helps for functions which is not marked as `inline`.