### PR TITLE
Minimal failing case for mono stackoverflow bug

### DIFF
--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -253,3 +253,15 @@ module Gen =
         |> Seq.pairwise 
         |> Seq.forall obj.ReferenceEquals
         |> Assert.True
+    [<Property>]
+    // this currently fails on mono
+    let ``recursive generator should not stackoverflow`` () =
+        let rec recursiveGenerator (iterations : int) : Gen<unit> = gen {
+            if iterations < 100000 then
+                let! _ = Gen.constant 1
+                return! recursiveGenerator (iterations + 1)
+            else
+                return ()
+        }
+
+        Prop.forAll (recursiveGenerator 0 |> Arb.fromGen) (fun () -> true)


### PR DESCRIPTION
This is obviously not ready to merge. I'm more posting this for discussion.

We have been having some problems with large tests causing a stackoverflow under mono. Our tests pass on the Microsoft CLR. I presume this is due to mono not handling tail call optimisation in all the cases where the CLR does.

This tests fails under mono (tested with: Mono JIT compiler version 4.0.2 (Stable 4.0.2.5/c99aa0c Wed Jun 24 10:04:37 UTC 2015).

Your recent change to remove delay means that the stackoverflow happens in less places. Before that I didn't need the Gen.constant 1 to cause the issue.

Do you have any advice on how we might go about fixing this?

They async computation expression goes to a lot of work to use a trampoline and I wonder if this might be why?
https://github.com/fsharp/fsharp/blob/master/src/fsharp/FSharp.Core/control.fs