### PR TITLE
Fixes compatiblity issues with VB.NET

### DIFF
--- a/src/FsCheck/AssemblyInfo.fs
+++ b/src/FsCheck/AssemblyInfo.fs
@@ -8,6 +8,7 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyVersionAttribute("2.0.6")>]
 [<assembly: AssemblyFileVersionAttribute("2.0.6")>]
 [<assembly: InternalsVisibleToAttribute("FsCheck.Test")>]
+[<assembly: Extension>]
 do ()
 
 module internal AssemblyVersionInformation =


### PR DESCRIPTION
Currently, the VB compiler does NOT recognize any extension methods defined in FsCheck. This causes serious awkwardness as the vast majority of the non-F# APIs reply on extensions. Fortunately, the fix is simple. More details maybe found here: http://latkin.org/blog/2014/04/30/f-extension-methods-in-roslyn/