### PR TITLE
Added information about versioning to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Releases:
 * [FsCheck with xUnit.NET integration](http://nuget.org/List/Packages/FsCheck.Xunit)
 * [FsCheck with NUnit integration](http://www.nuget.org/packages/FsCheck.Nunit/)
  
+FsCheck follows [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html).
+
 All AppVeyor builds are available using the NuGet feed: https://ci.appveyor.com/nuget/fscheck
 
 If using Paket, add the source at the top of `paket.dependencies`.


### PR DESCRIPTION
When troubleshooting versioning problems (e.g. with NuGet), it can be
useful for users to know that they can rely on a particular library to
follow Semantic Versioning. This enables users to assume that there are no
breaking changes among versions sharing the same major version, but that
there *are* breaking changes between versions with two different major
versions.

Case in point: https://github.com/fscheck/FsCheck/issues/137#issuecomment-136592290

In this pull request, I've implicitly *assumed* that FsCheck follows Semantic Versioning, which I don't know for certain, but that I'm seeing quite a few signs of.