### PR TITLE
Xunit2

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ nuget NUnit
 nuget NUnit.Runners
 nuget xunit prerelease
 nuget xunit.runner.console prerelease
-nuget xunit.runner.visualstudio prerelease
+nuget xunit.runner.visualstudio prerelease version_in_path: true
 nuget NuGet.CommandLine
 nuget SourceLink.Fake
 nuget FSharp.Formatting

--- a/paket.lock
+++ b/paket.lock
@@ -191,4 +191,4 @@ NUGET
       xunit.abstractions (>= 2.0.0)
       xunit.extensibility.core (2.1.0-beta4-build3109)
     xunit.runner.console (2.1.0-beta4-build3109)
-    xunit.runner.visualstudio (2.1.0-beta4-build1109)
+    xunit.runner.visualstudio (2.1.0-beta4-build1109) - version_in_path: true

--- a/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
+++ b/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
@@ -110,17 +110,6 @@
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
       <ItemGroup>
-        <Reference Include="xunit.assert">
-          <HintPath>..\..\packages\xunit.assert\lib\portable-net45+netcore45+wp8+wpa81\xunit.assert.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <ItemGroup>
         <Reference Include="xunit.core">
           <HintPath>..\..\packages\xunit.extensibility.core\lib\portable-net45+netcore45+wp8+wpa81\xunit.core.dll</HintPath>
           <Private>True</Private>

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -9,11 +9,11 @@ open Xunit.Sdk
 open Xunit.Abstractions
 
 type PropertyFailedException =
-    inherit XunitException
+    inherit Exception
     new (testResult:FsCheck.TestResult) = {
-        inherit XunitException(sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" testResult), "Sorry, no stack trace.") }
+        inherit Exception(sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" testResult)) }
     new (userMessage, innerException : exn) = {
-        inherit XunitException(userMessage, innerException) }
+        inherit Exception(userMessage, innerException) }
 
 //can not be an anonymous type because of let mutable.
 type XunitRunner() =

--- a/src/FsCheck.Xunit/paket.references
+++ b/src/FsCheck.Xunit/paket.references
@@ -1,2 +1,1 @@
 xunit.extensibility.execution
-xunit.assert


### PR DESCRIPTION
remove xunit.assert from FsCheck.Xunit. The XunitException did no provide any more functionality than the base Exception, so it was removed as well as the FsCheck.Xunit project paket.reference to xunit.assert.

add version_in_path to xunit.runner.visualstudio  of paket.dependencies
