### PR TITLE
Renamed variable.

### DIFF
--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -89,7 +89,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
 
     member this.Init() =
         let factAttribute = this.TestMethod.Method.GetCustomAttributes(typeof<PropertyAttribute>) |> Seq.head
-        let arbitraryOnMethod = factAttribute.GetNamedArgument "Arbitrary"
+        let arbitrariesOnMethod = factAttribute.GetNamedArgument "Arbitrary"
         let arbitrariesOnClass =
             this.TestMethod.TestClass.Class.GetCustomAttributes(typeof<ArbitraryAttribute>)
                 |> Seq.collect (fun attr -> attr.GetNamedArgument "Arbitrary")
@@ -97,7 +97,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
         let arbitraries =
             Config.Default.Arbitrary
             |> Seq.append arbitrariesOnClass
-            |> Seq.append arbitraryOnMethod
+            |> Seq.append arbitrariesOnMethod
             |> Seq.toList
 
         (factAttribute.GetNamedArgument("QuietOnSuccess"),


### PR DESCRIPTION
The Arbitrary property on the Property attribute is an array of Type
values, just like the class-level Arbitrary attribute. This change makes
this a bit clearer.

I know this isn't much of a pull request, but I just started looking through the source code for the `[<Property>]` attribute (triggered by the discussion over at #155), and fell over this small thing while reading the code.