### PR TITLE
Remove duplicated messages on failure

### DIFF
--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -147,7 +147,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                             upcast new TestFailed(test, timer.Total, (sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" xunitRunner.Result)), new PropertyFailedException(xunitRunner.Result))
                           | TestResult.False (testdata, originalArgs, shrunkArgs, Outcome.Exception e, seed)  ->
                             let message = sprintf "%s%s" Environment.NewLine (Runner.onFailureToString "" testdata originalArgs shrunkArgs seed)
-                            upcast new TestFailed(test, timer.Total, message, new PropertyFailedException(message, e))
+                            upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(message, e))
                           | TestResult.False (testdata, originalArgs, shrunkArgs, outcome, seed)  ->
                             summary.Failed <- summary.Failed + 1
                             upcast new TestFailed(test, timer.Total, (sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" xunitRunner.Result)), new PropertyFailedException(xunitRunner.Result))

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -150,7 +150,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                             upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(message, e))
                           | TestResult.False (testdata, originalArgs, shrunkArgs, outcome, seed)  ->
                             summary.Failed <- summary.Failed + 1
-                            upcast new TestFailed(test, timer.Total, (sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" xunitRunner.Result)), new PropertyFailedException(xunitRunner.Result))
+                            upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(xunitRunner.Result))
                 with
                     | ex -> upcast new TestFailed(test, timer.Total, "Exception during test:", ex)
 

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -144,7 +144,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                             new TestPassed(test, timer.Total, output) :> TestResultMessage
                           | TestResult.Exhausted testdata ->
                             summary.Failed <- summary.Failed + 1
-                            upcast new TestFailed(test, timer.Total, (sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" xunitRunner.Result)), new PropertyFailedException(xunitRunner.Result))
+                            upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(xunitRunner.Result))
                           | TestResult.False (testdata, originalArgs, shrunkArgs, Outcome.Exception e, seed)  ->
                             let message = sprintf "%s%s" Environment.NewLine (Runner.onFailureToString "" testdata originalArgs shrunkArgs seed)
                             upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(message, e))


### PR DESCRIPTION
Each commit message contains detailed explanation of the motivation for the change.