### PR TITLE
Migrate from xunit assertions to unquote

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,6 +3,7 @@ source https://www.nuget.org/api/v2
 nuget FAKE
 nuget NUnit
 nuget NUnit.Runners
+nuget Unquote
 nuget xunit
 nuget xunit.runner.console
 nuget xunit.runner.visualstudio version_in_path: true

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,6 +5,7 @@ nuget NUnit
 nuget NUnit.Runners
 nuget Unquote
 nuget xunit
+nuget xunit.core
 nuget xunit.runner.console
 nuget xunit.runner.visualstudio version_in_path: true
 nuget NuGet.CommandLine

--- a/paket.lock
+++ b/paket.lock
@@ -15,124 +15,140 @@ NUGET
     System.Collections (4.0.10) - framework: dnxcore50
       System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
       System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
       System.Runtime (>= 4.0.20) - framework: dnxcore50
       System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
       System.Threading (>= 4.0.0) - framework: dnxcore50
     System.Diagnostics.Contracts (4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
     System.Diagnostics.Debug (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
     System.Globalization (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
     System.IO (4.0.10) - framework: dnxcore50
       System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Text.Encoding (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20)
+      System.Text.Encoding (>= 4.0.0)
       System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
       System.Text.Encoding.Extensions (>= 4.0.0) - framework: dnxcore50
       System.Threading (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0)
     System.Linq (4.0.0) - framework: dnxcore50
-      System.Collections (>= 4.0.10) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
+      System.Collections (>= 4.0.10)
+      System.Diagnostics.Debug (>= 4.0.10)
+      System.Resources.ResourceManager (>= 4.0.0)
+      System.Runtime (>= 4.0.20)
+      System.Runtime.Extensions (>= 4.0.10)
+    System.Linq.Expressions (4.0.10) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
     System.ObjectModel (4.0.10) - framework: dnxcore50
-      System.Collections (>= 4.0.10) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Threading (>= 4.0.10) - framework: dnxcore50
+      System.Collections (>= 4.0.10)
+      System.Diagnostics.Debug (>= 4.0.10)
+      System.Resources.ResourceManager (>= 4.0.0)
+      System.Runtime (>= 4.0.20)
+      System.Threading (>= 4.0.10)
     System.Private.Uri (4.0.0) - framework: dnxcore50
     System.Reflection (4.0.10) - framework: dnxcore50
-      System.IO (>= 4.0.0) - framework: dnxcore50
-      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.IO (>= 4.0.0)
+      System.Reflection.Primitives (>= 4.0.0)
+      System.Runtime (>= 4.0.20)
     System.Reflection.Extensions (4.0.0) - framework: dnxcore50
       System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0)
       System.Reflection (>= 4.0.10) - framework: dnxcore50
       System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
       System.Reflection.TypeExtensions (>= 4.0.0) - framework: dnxcore50
       System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
       System.Runtime (>= 4.0.20) - framework: dnxcore50
       System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
     System.Reflection.Primitives (4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
       System.Threading (>= 4.0.0) - framework: dnxcore50
     System.Reflection.TypeExtensions (4.0.0) - framework: dnxcore50
       System.Diagnostics.Contracts (>= 4.0.0) - framework: dnxcore50
       System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
       System.Linq (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0)
       System.Reflection (>= 4.0.10) - framework: dnxcore50
       System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
       System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
       System.Runtime (>= 4.0.20) - framework: dnxcore50
       System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
     System.Resources.ResourceManager (4.0.0) - framework: dnxcore50
-      System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Globalization (>= 4.0.0)
+      System.Reflection (>= 4.0.0)
       System.Reflection (>= 4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
       System.Runtime (>= 4.0.20) - framework: dnxcore50
     System.Runtime (4.0.20) - framework: dnxcore50
       System.Private.Uri (>= 4.0.0) - framework: dnxcore50
     System.Runtime.Extensions (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime (>= 4.0.20)
     System.Text.Encoding (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
     System.Text.Encoding.Extensions (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
+      System.Text.Encoding (>= 4.0.10)
     System.Text.RegularExpressions (4.0.10) - framework: dnxcore50
-      System.Collections (>= 4.0.10) - framework: dnxcore50
-      System.Globalization (>= 4.0.10) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
-      System.Threading (>= 4.0.10) - framework: dnxcore50
+      System.Collections (>= 4.0.10)
+      System.Globalization (>= 4.0.10)
+      System.Resources.ResourceManager (>= 4.0.0)
+      System.Runtime (>= 4.0.20)
+      System.Runtime.Extensions (>= 4.0.10)
+      System.Threading (>= 4.0.10)
     System.Threading (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
+      System.Threading.Tasks (>= 4.0.0)
     System.Threading.Tasks (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0)
+    Unquote (3.0.0)
     xunit (2.1.0)
       xunit.assert (2.1.0)
       xunit.core (2.1.0)
-    xunit.abstractions (2.0.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+    xunit.abstractions (2.0.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
     xunit.assert (2.1.0)
-      System.Collections (>= 4.0.0) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
-      System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Linq (>= 4.0.0) - framework: dnxcore50
-      System.ObjectModel (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
-      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Text.RegularExpressions (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+      System.Collections (>= 4.0.0)
+      System.Diagnostics.Debug (>= 4.0.0)
+      System.Globalization (>= 4.0.0)
+      System.Linq (>= 4.0.0)
+      System.ObjectModel (>= 4.0.0)
+      System.Reflection (>= 4.0.0)
+      System.Reflection.Extensions (>= 4.0.0)
+      System.Runtime (>= 4.0.0)
+      System.Runtime.Extensions (>= 4.0.0)
+      System.Text.RegularExpressions (>= 4.0.0)
+      System.Threading.Tasks (>= 4.0.0)
     xunit.core (2.1.0)
-      System.Collections (>= 4.0.0) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
-      System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Linq (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
-      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
-      xunit.abstractions (>= 2.0.0) - framework: dnxcore50
-      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
-      xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
-    xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      System.Collections (>= 4.0.0)
+      System.Diagnostics.Debug (>= 4.0.0)
+      System.Globalization (>= 4.0.0)
+      System.Linq (>= 4.0.0)
+      System.Reflection (>= 4.0.0)
+      System.Reflection.Extensions (>= 4.0.0)
+      System.Runtime (>= 4.0.0)
+      System.Runtime.Extensions (>= 4.0.0)
+      System.Threading.Tasks (>= 4.0.0)
+      xunit.abstractions (>= 2.0.0)
+      xunit.extensibility.core (2.1.0)
+      xunit.extensibility.execution (2.1.0)
+    xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
       xunit.abstractions (2.0.0)
-    xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
-      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, >= net45
+    xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      System.Collections (>= 4.0.0)
+      System.Diagnostics.Debug (>= 4.0.0)
+      System.Globalization (>= 4.0.0)
+      System.IO (>= 4.0.0)
+      System.Linq (>= 4.0.0)
+      System.Linq.Expressions (>= 4.0.0)
+      System.Reflection (>= 4.0.0)
+      System.Reflection.Extensions (>= 4.0.0)
+      System.Runtime (>= 4.0.0)
+      System.Runtime.Extensions (>= 4.0.0)
+      System.Text.Encoding (>= 4.0.0)
+      System.Threading (>= 4.0.0)
+      System.Threading.Tasks (>= 4.0.0)
+      xunit.abstractions (>= 2.0.0)
+      xunit.extensibility.core (2.1.0)
     xunit.runner.console (2.1.0)
     xunit.runner.visualstudio (2.1.0) - version_in_path: true

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -11,6 +11,7 @@ module Arbitrary =
     open System.Collections.Generic
     open Helpers
     open Arb
+    open Swensen.Unquote
     
     let private addLabels (generator,shrinker) = ( generator |@ "Generator", shrinker |@ "Shrinker")
     
@@ -194,7 +195,7 @@ module Arbitrary =
     let ``Fun pattern works``(Fun (f:bool->bool)) =
         let a = f true
         let b = f false
-        Assert.True true
+        true =! true
 
     [<Property>]
     let SystemFunc (f: Func<int>) (vs: list<unit>) =

--- a/tests/FsCheck.Test/FsCheck.Test.fsproj
+++ b/tests/FsCheck.Test/FsCheck.Test.fsproj
@@ -144,17 +144,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <ItemGroup>
-        <Reference Include="xunit.assert">
-          <HintPath>..\..\packages\xunit.assert\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5.1'">
       <PropertyGroup>
         <__paket__xunit_core_props>win81\xunit.core</__paket__xunit_core_props>

--- a/tests/FsCheck.Test/FsCheck.Test.fsproj
+++ b/tests/FsCheck.Test/FsCheck.Test.fsproj
@@ -95,6 +95,35 @@
     </ProjectReference>
   </ItemGroup>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="Unquote">
+          <HintPath>..\..\packages\Unquote\lib\net40\Unquote.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Unquote">
+          <HintPath>..\..\packages\Unquote\lib\net45\Unquote.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Unquote">
+          <HintPath>..\..\packages\Unquote\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\Unquote.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="xunit.abstractions">

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -286,11 +286,10 @@ module Gen =
         // same as Gen.constant n, just to test while
         let convolutedGenNumber n =
             gen { let s = ref 0
-                  for c in [1..100] do
+                  for c in [1..n] do
                     s := !s + 1
                   return !s
                 }
-        convolutedGenNumber 100 
-        |> Gen.sample 1 10
-        |> Seq.forall ((=) 100) 
-        |> Assert.True
+        test <@ convolutedGenNumber 100 
+                |> Gen.sample 1 10
+                |> Seq.forall ((=) 100) @>

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -6,6 +6,7 @@ module Gen =
     open FsCheck
     open FsCheck.Xunit
     open Helpers
+    open Swensen.Unquote
 
     [<Property>]
     let Choose (Interval (l,h)) = 
@@ -193,7 +194,7 @@ module Gen =
         generated
         |> Seq.pairwise
         |> Seq.map (fun (a,b) -> a = b)
-        |> fun l -> Assert.DoesNotContain(false, l)
+        |> fun l -> test <@ Seq.forall id l @>
 
     //variant generators should be independent...this is not a good check for that.
 //    let Variant (v:char) =

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -277,10 +277,9 @@ module Gen =
                     s := !s + 1
                   return !s
                 }
-        convolutedGenNumber 100 
-        |> Gen.sample 1 10
-        |> Seq.forall ((=) 100) 
-        |> Assert.True
+        test <@ convolutedGenNumber 100 
+                |> Gen.sample 1 10
+                |> Seq.forall ((=) 100) @>
 
     [<Fact>]
     let ``GenBuilder.For``() =

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -79,7 +79,7 @@ module Runner =
     let ``should pick up replay seeds from PropertyAttribute without parens``(a:int, b:string) =
         //testing the replay separately in other tests - this just checks we can run
         //this test
-        Assert.True true
+        true =! true
 
     [<Property(Replay="(54321,67584)")>]
     let ``should pick up replay seeds from PropertyAttribute with parens``(a:int, b:string) =

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -71,9 +71,9 @@ module Runner =
             Seq.initInfinite (fun i -> doOne(123,654321))
             |> Seq.take(5)
             |> Seq.distinct
-        Assert.Equal(1,Seq.length same)
-        Assert.NotEqual<string>("should have failed", Seq.head same)
-        Assert.Contains("(123,654321)", Seq.head same);
+        1 =! Seq.length same
+        "should have failed" <>! Seq.head same
+        test <@ (Seq.head same).Contains "(123,654321)" @>
 
     [<Property(Replay="54321,67584")>]
     let ``should pick up replay seeds from PropertyAttribute without parens``(a:int, b:string) =

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -90,7 +90,7 @@ module Runner =
     type TypeToInstantiate() =
         [<Property>]
         let ``should run a property on an instance``(random:int) =
-            Assert.True true
+            true =! true
 
     [<Arbitrary(typeof<TestArbitrary2>)>]
     module ModuleWithArbitrary =

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -85,7 +85,7 @@ module Runner =
     let ``should pick up replay seeds from PropertyAttribute with parens``(a:int, b:string) =
         //testing the replay separately in other tests - this just checks we can run
         //this test
-        Assert.True true
+        true =! true
 
     type TypeToInstantiate() =
         [<Property>]

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -7,6 +7,7 @@ module Runner =
     open FsCheck
     open FsCheck.Xunit
     open Helpers
+    open Swensen.Unquote
 
     type TestArbitrary1 =
         static member PositiveDouble() =
@@ -54,9 +55,9 @@ module Runner =
             Seq.initInfinite (fun i -> doOne(123,654321))
             |> Seq.take(5)
             |> Seq.distinct
-        Assert.Equal(1,Seq.length same)
-        Assert.NotEqual<string>("should have failed", Seq.head same)
-        Assert.Contains("(123,654321)", Seq.head same);
+        1 =! Seq.length same
+        "should have failed" <>! Seq.head same
+        test <@ (Seq.head same).Contains "(123,654321)" @>
 
     [<Fact>]
     let ``should replay property with complex set of generators``() =

--- a/tests/FsCheck.Test/StateMachine.fs
+++ b/tests/FsCheck.Test/StateMachine.fs
@@ -6,6 +6,7 @@ module StateMachine =
     open FsCheck
     open FsCheck.Experimental
     open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
+    open Swensen.Unquote
 
     type SimpleModel() =
         let count = ref 0
@@ -25,11 +26,11 @@ module StateMachine =
             StateMachine.generate checkSimpleModelSpec
             |> Gen.sample 10 10
         for { Setup = _,create; Operations = comms } in commands do
-            Assert.IsType<SimpleModel>(create.Actual()) |> ignore
-            Assert.Equal(0, create.Model())
+            typeof<SimpleModel> =! create.Actual().GetType()
+            0 =! create.Model()
             for m,comm in comms do
-                Assert.True(comm.Pre 5)
-                Assert.Equal(6, comm.Run 5)
+                test <@ comm.Pre 5 @>
+                6 =! comm.Run 5
 
 
     //this spec is created using preconditions such that the only valid sequence is setFalse,setTrue

--- a/tests/FsCheck.Test/StateMachine.fs
+++ b/tests/FsCheck.Test/StateMachine.fs
@@ -55,11 +55,9 @@ module StateMachine =
 
     [<Fact>]
     let ``generate commands should never violate precondition``() =
-        StateMachine.generate checkPreconditionSpec
-        |> Gen.sample 100 10
-        |> Seq.forall (fun { Setup = _,c; Operations = cmds } -> checkPreconditions (c.Model()) cmds)
-        |> Assert.True
-        
+        test <@ StateMachine.generate checkPreconditionSpec
+                |> Gen.sample 100 10
+                |> Seq.forall (fun { Setup = _,c; Operations = cmds } -> checkPreconditions (c.Model()) cmds) @>
 
     [<Fact>]
     let ``shrink commands should never violate precondition``() =

--- a/tests/FsCheck.Test/StateMachine.fs
+++ b/tests/FsCheck.Test/StateMachine.fs
@@ -61,13 +61,11 @@ module StateMachine =
 
     [<Fact>]
     let ``shrink commands should never violate precondition``() =
-        StateMachine.generate checkPreconditionSpec 
-        |> Gen.sample 100 10
-        |> Seq.map (StateMachine.shrink checkPreconditionSpec) 
-        |> Seq.concat
-        |> Seq.forall (fun { Setup = _,c; Operations = cmds } -> checkPreconditions (c.Model()) cmds)
-        |> Assert.True
-        
+        test <@ StateMachine.generate checkPreconditionSpec 
+                |> Gen.sample 100 10
+                |> Seq.map (StateMachine.shrink checkPreconditionSpec) 
+                |> Seq.concat
+                |> Seq.forall (fun { Setup = _,c; Operations = cmds } -> checkPreconditions (c.Model()) cmds) @>
 
     //a counter that never goes below zero
     type Counter(?dontcare:int) =

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -88,7 +88,7 @@ module TypeClass =
                 .Discover(true, typeof<ArrayInstance>)
                 .DiscoverAndMerge(true, typeof<PrimitiveInstance>) //so the int is defined too
                 .InstanceFor<int[,],ITypeClassUnderTest<int[,]>>()
-        Assert.Equal(2, instance.GetSomething)
+        2 =! instance.GetSomething
 
     [<Fact>]
     let ``should instantiate unknown type using catchall``() =

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -78,7 +78,7 @@ module TypeClass =
                 .Discover(true, typeof<PrimitiveInstance>)
                 .InstanceFor<int,ITypeClassUnderTest<int>>()
 
-        Assert.Equal(1, instance.GetSomething)
+        1 =! instance.GetSomething
 
     [<Fact>]
     let ``should instantiate array type``() =

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -53,8 +53,8 @@ module TypeClass =
             TypeClass<ITypeClassUnderTest<_>>
                 .New()
                 .Discover(true, typeof<ArrayInstance>)
-        Assert.Equal(1, typeClass.Instances.Count)
-        Assert.Contains((Array typeof<_[,]>), typeClass.Instances)
+        1 =! typeClass.Instances.Count
+        test <@ typeClass.Instances.Contains (Array typeof<_[,]>) @>
 
     type CatchAllInstance() =
         static member CatchAll() =

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -38,9 +38,9 @@ module TypeClass =
             TypeClass<ITypeClassUnderTest<_>>
                 .New()
                 .Discover(true, typeof<PrimitiveInstance>)
-        Assert.Equal(1, typeClass.Instances.Count)
-        Assert.Contains((Primitive typeof<int>), typeClass.Instances) 
-        Assert.False typeClass.HasCatchAll
+        1 =! typeClass.Instances.Count
+        test <@ typeClass.Instances.Contains (Primitive typeof<int>) @>
+        false =! typeClass.HasCatchAll
 
     type ArrayInstance() =
         static member Array2() =

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -97,7 +97,7 @@ module TypeClass =
                 .New()
                 .Discover(true, typeof<CatchAllInstance>)
                 .InstanceFor<string,ITypeClassUnderTest<string>>() //string not defined explicitly
-        Assert.Equal(3, instance.GetSomething)
+        3 =! instance.GetSomething
 
 
 

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -21,8 +21,7 @@ module TypeClass =
 
     [<Fact>]
     let ``should throw when intialized with non-generic type``() =
-        Assert.Throws<Exception>(fun () -> TypeClass<string>.New() |> ignore) 
-        |> ignore
+        raises<Exception> <@ TypeClass<string>.New() @>
 
     type PrimitiveInstance() =
         static member Int() =

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -67,8 +67,8 @@ module TypeClass =
             TypeClass<ITypeClassUnderTest<_>>
                 .New()
                 .Discover(true, typeof<CatchAllInstance>)
-        Assert.True typeClass.HasCatchAll
-        Assert.Equal(1,typeClass.Instances.Count)
+        test <@ typeClass.HasCatchAll @>
+        1 =! typeClass.Instances.Count
 
     [<Fact>]
     let ``should instantiate primitive type``() =

--- a/tests/FsCheck.Test/TypeClass.fs
+++ b/tests/FsCheck.Test/TypeClass.fs
@@ -7,6 +7,7 @@ module TypeClass =
     open FsCheck
     open FsCheck.Xunit
     open FsCheck.TypeClass
+    open Swensen.Unquote
 
     type ITypeClassUnderTest<'a> =
         abstract GetSomething : int
@@ -14,9 +15,9 @@ module TypeClass =
     [<Fact>]
     let ``should be empty on initialization``() =
         let typeClassDef = TypeClass<ITypeClassUnderTest<_>>.New()
-        Assert.Equal(typedefof<ITypeClassUnderTest<_>>,typeClassDef.Class)
-        Assert.Empty typeClassDef.Instances
-        Assert.False typeClassDef.HasCatchAll
+        typedefof<ITypeClassUnderTest<_>> =! typeClassDef.Class
+        test <@ typeClassDef.Instances.IsEmpty @>
+        false =! typeClassDef.HasCatchAll
 
     [<Fact>]
     let ``should throw when intialized with non-generic type``() =

--- a/tests/FsCheck.Test/paket.references
+++ b/tests/FsCheck.Test/paket.references
@@ -1,2 +1,3 @@
 xunit
 xunit.runner.visualstudio
+Unquote

--- a/tests/FsCheck.Test/paket.references
+++ b/tests/FsCheck.Test/paket.references
@@ -1,3 +1,3 @@
-xunit
 xunit.runner.visualstudio
 Unquote
+xunit.core


### PR DESCRIPTION
Addresses #160 

A couple of comments:

- There's more than one way to express many of the assertions with Unquote. As you can tell, I tend to favour the built-in operators `=!` and `<>!` over `test <@ ... @>` in most cases. It would, however, also be possible to stick more consistently with the `test <@ ... @>` style. Let me know if I should change that.
- With the built-in operators `=!` and `<>!`, the assertions become so terse that they almost 'drown' in the test. If we stick with these operators, I would recommend adopting this heuristic for formatting tests: http://blog.ploeh.dk/2013/06/24/a-heuristic-for-formatting-code-according-to-the-aaa-pattern