### PR TITLE
Add QuietOnSuccess option to Config

### DIFF
--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -100,25 +100,25 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
             |> Seq.append arbitrariesOnMethod
             |> Seq.toList
 
-        (factAttribute.GetNamedArgument("QuietOnSuccess"),
-         {Config.Default with
+        { Config.Default with
                 Replay = factAttribute.GetNamedArgument("ReplayStdGen")
                 MaxTest = factAttribute.GetNamedArgument("MaxTest")
                 MaxFail = factAttribute.GetNamedArgument("MaxFail")
                 StartSize = factAttribute.GetNamedArgument("StartSize")
                 EndSize = factAttribute.GetNamedArgument("EndSize")
+                QuietOnSuccess = factAttribute.GetNamedArgument("QuietOnSuccess")
                 Every = if factAttribute.GetNamedArgument("Verbose") then Config.Verbose.Every else Config.Quick.Every
                 EveryShrink = if factAttribute.GetNamedArgument("Verbose") then Config.Verbose.EveryShrink else Config.Quick.EveryShrink
                 Arbitrary = arbitraries
                 Runner = new XunitRunner()
-            })
+            }
 
     override this.RunAsync(diagnosticMessageSink:IMessageSink, messageBus:IMessageBus, constructorArguments:obj [], aggregator:ExceptionAggregator, cancellationTokenSource:Threading.CancellationTokenSource) =
         let test = new XunitTest(this, this.DisplayName)
         let summary = new RunSummary(Total = 1);
 
         let testExec() =
-            let (quietOnSuccess,config) = this.Init()
+            let config = this.Init()
             let timer = ExecutionTimer()
             let result =
                 try
@@ -137,10 +137,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
 
                     match xunitRunner.Result with
                           | TestResult.True _ ->
-                            let output =
-                                if quietOnSuccess
-                                then ""
-                                else Runner.onFinishedToString "" xunitRunner.Result
+                            let output = Runner.onFinishedToString "" xunitRunner.Result
                             new TestPassed(test, timer.Total, output) :> TestResultMessage
                           | TestResult.Exhausted testdata ->
                             summary.Failed <- summary.Failed + 1

--- a/src/FsCheck/RunnerExtensions.fs
+++ b/src/FsCheck/RunnerExtensions.fs
@@ -22,6 +22,7 @@ type Configuration() =
     let mutable everyShrink = Config.Quick.EveryShrink
     let mutable startSize = Config.Quick.StartSize
     let mutable endSize = Config.Quick.EndSize
+    let mutable quietOnSuccess = Config.Quick.QuietOnSuccess
     let mutable runner = Config.Quick.Runner
     let mutable replay = Config.Quick.Replay
 
@@ -48,6 +49,9 @@ type Configuration() =
     ///The size to use for the last test, when all the tests are passing. The size increases linearly between Start- and EndSize.
     member __.EndSize with get() = endSize and set(v) = endSize <- v
 
+    ///If set, suppresses the output from the test if the test is successful.
+    member __.QuietOnSuccess with get() = quietOnSuccess and set(v) = quietOnSuccess <- v
+
     ///A custom test runner, e.g. to integrate with a test framework like xUnit or NUnit. 
     member __.Runner with get() = runner and set(v) = runner <- v
 
@@ -64,6 +68,7 @@ type Configuration() =
           EveryShrink = everyShrink
           StartSize = startSize
           EndSize = endSize
+          QuietOnSuccess = quietOnSuccess
           Runner = runner
           Replay = replay
           Arbitrary = []

--- a/tests/FsCheck.Test/Property.fs
+++ b/tests/FsCheck.Test/Property.fs
@@ -97,7 +97,7 @@ module Property =
     let private areSame (r0:Result) (r1:TestResult) =
         let testData =
             match r1 with 
-            | TestResult.True td -> td
+            | TestResult.True (td,_) -> td
             | TestResult.False (td,_,_,_,_) -> td
             | TestResult.Exhausted td -> td
 


### PR DESCRIPTION
This PR copies the `QuietOnSuccess` option from `PropertyAttribute` to `Config`, to allow its use with `Check.One`, `Check.All`, etc. E.g

    Check.One ({Config.Quick with QuietOnSuccess = true}, property)

I'm not sure where to add tests for this change, am open to suggestions here.