### PR TITLE
Update xUnit summary on property failure due to exception

### DIFF
--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -143,13 +143,16 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                             summary.Failed <- summary.Failed + 1
                             upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(xunitRunner.Result))
                           | TestResult.False (testdata, originalArgs, shrunkArgs, Outcome.Exception e, seed)  ->
+                            summary.Failed <- summary.Failed + 1
                             let message = sprintf "%s%s" Environment.NewLine (Runner.onFailureToString "" testdata originalArgs shrunkArgs seed)
                             upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(message, e))
                           | TestResult.False (testdata, originalArgs, shrunkArgs, outcome, seed)  ->
                             summary.Failed <- summary.Failed + 1
                             upcast new TestFailed(test, timer.Total, "", new PropertyFailedException(xunitRunner.Result))
                 with
-                    | ex -> upcast new TestFailed(test, timer.Total, "Exception during test:", ex)
+                    | ex ->
+                      summary.Failed <- summary.Failed + 1
+                      upcast new TestFailed(test, timer.Total, "Exception during test:", ex)
 
             messageBus.QueueMessage(result) |> ignore
             summary.Time <- summary.Time + result.ExecutionTime


### PR DESCRIPTION
This initially comes from the xUnit runner failing to increment the failure count on an exception being thrown during property evaluation (as might happen when using Unquote). In this case, the test was not being added to the summary as failed, though that was the test result returned. The number of failures reported ends up being xUnit's exit code, so if a property ended up throwing an exception and failing, it might not be seen as a failure to an external program (such as FAKE) that relied on that exit code.

This change increments those failure counters on a thrown exception so that it appropriately influences xUnit's exit code and matches user expectations in the console. This PR is also a bit of a question: it looks like these two cases were singled out for not incrementing the failure count, so it may be for a reason that I don't know about.