### PR TITLE
Add support for async methods returning Task<T> or Task

### DIFF
--- a/examples/FsCheck.XUnit.CSharpExamples/ReverseFixture.cs
+++ b/examples/FsCheck.XUnit.CSharpExamples/ReverseFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using FsCheck.Xunit;
 
 namespace FsCheck.XUnit.CSharpExamples
@@ -45,6 +46,40 @@ namespace FsCheck.XUnit.CSharpExamples
 
         [Property]
         public bool ShouldFail_Exception(int[] xs)
+        {
+            throw new InvalidOperationException("Test failed!");
+        }
+
+        [Property]
+        public async Task<bool> ShouldFail_Async(int x)
+        {
+            await Task.Yield();
+            return false;
+        }
+
+        [Property]
+        public async Task<bool> ShouldSucceed_Async(int x)
+        {
+            await Task.Yield();
+            return true;
+        }
+
+        [Property]
+        public async Task ShouldFailException_Async(int x)
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("Test failed!");
+        }
+
+
+        [Property]
+        public async Task ShouldSucceedNoException_Async(int x)
+        {
+            await Task.Yield();
+        }
+
+        [Property]
+        public async Task<bool> ShouldFailException2_Async(int x)
         {
             throw new InvalidOperationException("Test failed!");
         }

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -132,14 +132,36 @@ module Arb =
         let empty = TypeClass<Arbitrary<obj>>.New()
         empty.Discover(onlyPublic=true,instancesType=typeof<Default>)
 
+    #if !PCL
+    open System.Runtime.Remoting.Messaging
+
+    let threadLocalDataName = "fscheck-arbitrary"
+
+    let internal setArbitrary instance =
+        CallContext.LogicalSetData(threadLocalDataName, instance)
+
+    let internal getArbitrary () =
+        match CallContext.LogicalGetData(threadLocalDataName) with
+        | null -> defaultArbitrary
+        | arb -> arb :?> TypeClass<Arbitrary<obj>>
+
+    #else
     let internal arbitrary = new ThreadLocal<TypeClass<Arbitrary<obj>>>(fun () -> defaultArbitrary)
+
+    let internal setArbitrary instance =
+        arbitrary.Value <- instance
+
+    let internal getArbitrary () =
+        arbitrary.Value
+    #endif
 
     ///Register the generators that are static members of the given type.
     [<CompiledName("Register")>]
     let registerByType t = 
-        let newTypeClass = arbitrary.Value.Discover(onlyPublic=true,instancesType=t)
-        let result = arbitrary.Value.Compare newTypeClass
-        arbitrary.Value <- arbitrary.Value.Merge newTypeClass
+        let arb = getArbitrary()
+        let newTypeClass = arb.Discover(onlyPublic=true,instancesType=t)
+        let result = arb.Compare newTypeClass
+        setArbitrary (arb.Merge newTypeClass)
         result
 
     ///Register the generators that are static members of the type argument.
@@ -148,7 +170,7 @@ module Arb =
 
     ///Get the Arbitrary instance for the given type.
     [<CompiledName("From")>]
-    let from<'Value> = arbitrary.Value.InstanceFor<'Value,Arbitrary<'Value>>()
+    let from<'Value> = getArbitrary().InstanceFor<'Value,Arbitrary<'Value>>()
 
     ///Returns a Gen<'Value>
     [<CompiledName("Generate")>]
@@ -169,9 +191,9 @@ module Arb =
                         |> Seq.takeWhile ((|>|) n) }
         |> Seq.distinct
 
-    let internal getGenerator t = arbitrary.Value.GetInstance t |> unbox<IArbitrary> |> (fun arb -> arb.GeneratorObj)
+    let internal getGenerator t = getArbitrary().GetInstance t |> unbox<IArbitrary> |> (fun arb -> arb.GeneratorObj)
 
-    let internal getShrink t = arbitrary.Value.GetInstance t |> unbox<IArbitrary> |> (fun arb -> arb.ShrinkerObj)
+    let internal getShrink t = getArbitrary().GetInstance t |> unbox<IArbitrary> |> (fun arb -> arb.ShrinkerObj)
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     let toGen (arb:Arbitrary<'Value>) = arb.Generator

--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -272,13 +272,13 @@ module Runner =
 
     let internal check config p = 
         //save so we can restore after the run
-        let defaultArbitrary = Arb.arbitrary.Value
+        let defaultArbitrary = Arb.getArbitrary()
         let merge newT (existingTC:TypeClass<_>) = existingTC.DiscoverAndMerge(onlyPublic=true,instancesType=newT)
-        Arb.arbitrary.Value <- List.foldBack merge config.Arbitrary defaultArbitrary
+        Arb.setArbitrary (List.foldBack merge config.Arbitrary defaultArbitrary)
         try
             runner config (property p)
         finally
-            Arb.arbitrary.Value <- defaultArbitrary
+            Arb.setArbitrary defaultArbitrary
 
     let private checkMethodInfo = 
         typeof<TestStep>.DeclaringType.GetTypeInfo().DeclaredMethods 

--- a/src/FsCheck/Testable.fs
+++ b/src/FsCheck/Testable.fs
@@ -136,6 +136,7 @@ module private Testable =
          
         let ofBool b = ofResult <| if b then Res.succeeded else Res.failed
 
+
         let mapRoseResult f a = property a |> Property.GetGen |> Gen.map f |> Property
 
         let mapResult f = mapRoseResult (Rose.map f)
@@ -227,3 +228,28 @@ module private Testable =
         static member List() =
             { new Testable<list<'a>> with
                 member __.Property l = List.fold (.&) (property <| List.head l) (List.tail l) }
+
+        #if !PCL
+
+        static member Task() =
+            { new Testable<System.Threading.Tasks.Task> with
+                member __.Property t =
+                    try
+                        t.Wait()
+                        property true
+                    with
+                    | :? AggregateException as agg ->
+                        Prop.ofResult (Res.exc agg.InnerException)
+                    | ex -> Prop.ofResult (Res.exc ex) }
+
+        static member TaskOfT() =
+            { new Testable<System.Threading.Tasks.Task<'t>> with
+                member __.Property t =
+                    try
+                        t.Result |> property
+                    with
+                    | :? AggregateException as agg ->
+                        Prop.ofResult (Res.exc agg.InnerException)
+                    | ex -> Prop.ofResult (Res.exc ex) }
+
+        #endif


### PR DESCRIPTION
This should fix #167 but I haven't had a chance to test it on anything
very async-heavy.

----

We do this by adding a Testable instance for Task<T> and Task,
and also making the thread-local storage of typeclass instances
use CallContext instead.

Support for Task<T> and Task is only enabled for non-PCL builds
as PCL doesn't have the CallContext class.
