### PR TITLE
Performance optimizations

### DIFF
--- a/src/FsCheck/Common.fs
+++ b/src/FsCheck/Common.fs
@@ -12,7 +12,12 @@ namespace FsCheck
 
 module internal Common =
 
+    open System
+#if PCL
     open System.Collections.Generic
+
+    ///Create the Memoizer
+    let memoizer () = new Dictionary<_,_>()
 
     ///Memoize the given function using the given dictionary
     let memoizeWith (memo:IDictionary<'a,'b>) (f: 'a -> 'b) =
@@ -25,12 +30,22 @@ module internal Common =
                         let res = f n
                         memo.Add(n,res)
                         res)
+#else
+    open System.Collections.Concurrent
+
+    ///Create the Memoizer
+    let memoizer () = new ConcurrentDictionary<_,_>()
+
+    ///Memoize the given function using the given dictionary
+    let memoizeWith (memo:ConcurrentDictionary<'a,'b>) (f: 'a -> 'b) =
+        let ff = Func<'a,'b>(f)
+        fun n ->
+            memo.GetOrAdd (n, ff)
+#endif
 
     ///Memoize the given function.
     let memoize f =
-        let t = new Dictionary<_,_>()
-        memoizeWith t f
-
+        memoizeWith (memoizer ()) f
     let flip f x y = f y x
 
     //the following three are from Don Syme's blog:

--- a/src/FsCheck/Reflect.fs
+++ b/src/FsCheck/Reflect.fs
@@ -60,13 +60,15 @@ module internal Reflect =
         ctor.Invoke
 
     /// Returns the case name, type, and functions that will construct a constructor and a reader of a union type respectively
-    let getUnionCases unionType : (string * (int * System.Type list * (obj[] -> obj) * (obj -> obj[]))) list = 
+    let getUnionCases : Type -> (string * (int * System.Type list * (obj[] -> obj) * (obj -> obj[]))) list =
+        Common.memoize (fun (unionType:Type) ->
         [ for case in FSharpType.GetUnionCases(unionType, true) ->
             let types =    [ for fld in case.GetFields() -> fld.PropertyType ]
             let ctorFn =   FSharpValue.PreComputeUnionConstructor(case, true)
             let readerFn = FSharpValue.PreComputeUnionReader(case, true)
                 
             case.Name, (case.Tag, types, ctorFn, readerFn)]
+          )
 
     /// Get reader for union case name (aka tag)
     let getUnionTagReader unionType = 

--- a/src/FsCheck/TypeClass.fs
+++ b/src/FsCheck/TypeClass.fs
@@ -14,7 +14,6 @@ namespace FsCheck
 module TypeClass =
 
     open System
-    open System.Collections.Generic
     open System.Reflection
 
     open Common
@@ -101,7 +100,7 @@ module TypeClass =
 
         let instances = defaultArg instances Map.empty
         let keySet map = map |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-        let memo = new Dictionary<_,_>() //should fix memo bug since the memo table is re-initialized when a new registration is done
+        let memo = memoizer() //should fix memo bug since the memo table is re-initialized when a new registration is done
          
         member __.Class = typedefof<'TypeClass>
         member __.Instances = instances |> keySet


### PR DESCRIPTION
Performance optimization for F# Unions
==============================

When using FsCheck to generate test cases for my optimized Tries I thought FsCheck was taking too long. 

After some profiling I noticed FsCheck spent most of its time in: `getUnionCases`. In addition I noticed non-working memoization in `reflectObj`

So I:

1. Added memoization to `getUnionCases`
1. Fixed broken memoization of `reflectObj`
1. Switched to `ConcurrentDictionary<>` for `memoize`
   Doesn't lock on lookups
   Portable binaries still uses lock

Performance numbers previous to change:
6x100 property tests  ==> ~30 sec

Performance numbers after change:
6x100 property tests  ==> ~1 sec

Your milage might differ depending on how much your test cases calls `getUnionCases`/`reflectObj`

Regard,
Mårten