### PR TITLE
Allow reflector to derive generator for unions with a private constructor

### DIFF
--- a/src/FsCheck/Reflect.fs
+++ b/src/FsCheck/Reflect.fs
@@ -23,7 +23,7 @@ module internal Reflect =
 //        ||| BindingFlags.NonPublic ||| BindingFlags.Public
 
     let isRecordType (ty : Type) = FSharpType.IsRecord(ty, true) //recordFieldBindingFlags)
-    let isUnionType ty = FSharpType.IsUnion ty
+    let isUnionType ty = FSharpType.IsUnion(ty, true)
     let isTupleType ty = FSharpType.IsTuple ty
     let getPublicCtors (ty: Type) = ty.GetTypeInfo().DeclaredConstructors |> Seq.filter (fun c -> c.IsPublic)
     let isCSharpRecordType (ty: Type) = 

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -413,3 +413,14 @@ module Arbitrary =
     let ``Derive generator for concrete class with one constructor with two parameters``() =
         generate<FakeRecord> |> sample 10 |> ignore
 
+    type PrivateRecord = private { a: int; b: string }
+
+    [<Fact>]
+    let ``Derive generator for private two value record``() =
+        generate<PrivateRecord> |> sample 10 |> ignore
+
+    type PrivateUnion = private | Case1 | Case2 of string
+
+    [<Fact>]
+    let ``Derive generator for private two case union``() =
+        generate<PrivateUnion> |> sample 10 |> ignore


### PR DESCRIPTION
We can do it for records, so let's also do it with unions. Tests included for the arbitrary generator for both private unions and private records.