### PR TITLE
Final runner output for xunit is missing in ReSharper

### DIFF
--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -146,7 +146,8 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                     match xunitRunner.Result with
                           | TestResult.True _ ->
                             let output = Runner.onFinishedToString "" xunitRunner.Result
-                            new TestPassed(test, timer.Total, outputHelper.Output + output) :> TestResultMessage
+                            outputHelper.WriteLine(output)
+                            new TestPassed(test, timer.Total, outputHelper.Output) :> TestResultMessage
                           | TestResult.Exhausted _ ->
                             summary.Failed <- summary.Failed + 1
                             upcast new TestFailed(test, timer.Total, outputHelper.Output, new PropertyFailedException(xunitRunner.Result))
@@ -160,7 +161,8 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                 with
                     | ex ->
                       summary.Failed <- summary.Failed + 1
-                      upcast new TestFailed(test, timer.Total, outputHelper.Output + "Exception during test:", ex)
+                      outputHelper.WriteLine("Exception during test")
+                      upcast new TestFailed(test, timer.Total, outputHelper.Output, ex)
 
            
             messageBus.QueueMessage(result) |> ignore


### PR DESCRIPTION
ReSharper doesn't display the `Ok, passed 100 tests` message. This is because the message is appended to the test's full output when creating the `TestPassed` message, but isn't reported as an output message.

ReSharper displays output as it happens, so relies on the output messages. The VS and console runners use the complete output, passed to the `TestPassed` message, so they get to display the `Ok, passed 100 tests` message correctly.

The intent of the output value passed to the `TestPassed` message is to be a concatenation of all the output messages sent during the run. It is [not intended to have any content that wasn't reported as an output message](https://github.com/xunit/resharper-xunit/issues/104#issuecomment-161717699). This code change makes sure the output is sent as a message before being passed to `TestPassed`.