### PR TITLE
support shrinking null values for C# compatibility

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -39,7 +39,18 @@ type Arbitrary<'a>() =
         Seq.empty
     interface IArbitrary with
         member x.GeneratorObj = (x.Generator :> IGen).AsGenObject
-        member x.ShrinkerObj o = (x.Shrinker (unbox o)) |> Seq.map box
+        member x.ShrinkerObj (o:obj) : seq<obj> =
+            let tryUnbox v =
+                try
+                    Some (unbox v)
+                with
+                    | _ -> None
+
+            match tryUnbox o with
+                | Some v -> x.Shrinker v |> Seq.map box
+                | None -> Seq.empty
+
+
 
 ///Computation expression builder for Gen.
 [<AutoOpen>]


### PR DESCRIPTION
I ran into an issue writing tests in C# for data transfer objects defined in F#.  I've found that F# records make good DTOs because of deep equality and immutability.  However, if you are referring to F# records in C#, records and object types can have null values even when this is not allowed in F# itself.  Since null is an acceptable value in C#, you should be able to generate nulls and return them as an option for a shrunk value.  This would all be possible if I wrote a complete shrinker, but I'd much rather leverage the existing shrinker for F# records when possible.  However if you try to shrink a null value for a field in an F# record, FsCheck crashes because you cannot unbox a null into an F# type unless the AllowNullLiteral attribute is set.

You could argue that if you intend to expose your F# records in C# you should always specify the AllowNullLiteral attribute.  However, since this attribute is set on the type and not on its references, you cannot control under which circumstances you wish to allow null.  In any event, it is fairly trivial to check for null and infer that additional shrinking is impossible.  Or in the more general case, if a value cannot be unboxed (essentially implying an object state that F# does not consider valid), additional shrinking is impossible.  That's the solution I've opted for here.

Let me know if you'd prefer another way of dealing with this issue, or if there are any changes you'd like me to make.