### PR TITLE
[WIP] add .NET Core support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ release.cmd
 docs/tools/FSharp.Formatting.svclog
 docs/tools/XmlWriter
 
+project.lock.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,27 @@
 init:
   - git config --global core.autocrlf input
+
+install:
+  # Download install script to install .NET cli in .dotnet dir
+  - ps: $env:CLI_VERSION = "1.0.0-beta-002071"
+  - ps: mkdir -Force ".\scripts\obtain\" | Out-Null
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1" -OutFile ".\scripts\obtain\install.ps1"
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
+  - ps: '& .\scripts\obtain\install.ps1 -Channel "preview" -version "$env:CLI_VERSION" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath'
+  # add dotnet to PATH
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  # dotnet info
+  - ps: dotnet --info
+
 build_script:
   - cmd: ./build.cmd CI
+  # build and create package
+  - ps: dotnet restore
+  - ps: cd src\FsCheck
+  - ps: dotnet pack --configuration Release
+
 test: off
 version: '{build}'
 artifacts:
   - path: bin\*.nupkg
+  - path: src\FsCheck\bin\Release\*.nupkg

--- a/src/FsCheck.Dotnetcli.Tests/NuGet.Config
+++ b/src/FsCheck.Dotnetcli.Tests/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/FsCheck.Dotnetcli.Tests/Program.fs
+++ b/src/FsCheck.Dotnetcli.Tests/Program.fs
@@ -1,0 +1,9 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv = 
+    printfn "Hello World!"
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/src/FsCheck.Dotnetcli.Tests/Program.fs
+++ b/src/FsCheck.Dotnetcli.Tests/Program.fs
@@ -2,8 +2,15 @@
 
 open System
 
+open FsCheck
+
 [<EntryPoint>]
 let main argv = 
     printfn "Hello World!"
     printfn "%A" argv
+    
+    let revRevIsOrig (xs:list<int>) = List.rev(List.rev xs) = xs
+    
+    Check.Quick revRevIsOrig
+    
     0 // return an integer exit code

--- a/src/FsCheck.Dotnetcli.Tests/project.json
+++ b/src/FsCheck.Dotnetcli.Tests/project.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compilerName": "fsc",
+  "compileFiles": [
+    "Program.fs"
+  ],
+  "dependencies": {
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0-rc2-23925"
+    }
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": [
+        "portable-net45+win8",
+        "dnxcore50"
+      ]
+    }
+  }
+}

--- a/src/FsCheck.Dotnetcli.Tests/project.json
+++ b/src/FsCheck.Dotnetcli.Tests/project.json
@@ -7,19 +7,11 @@
   "compileFiles": [
     "Program.fs"
   ],
-  "dependencies": {
-    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc2-23925"
-    }
-  },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [
-        "portable-net45+win8",
-        "dnxcore50"
-      ]
+    "net46" : {
+      "dependencies": {
+        "FsCheck":  { "version": "1.0.0", "type": "build" }
+      }
     }
   }
 }

--- a/src/FsCheck.Dotnetcli.Tests/project.json
+++ b/src/FsCheck.Dotnetcli.Tests/project.json
@@ -8,6 +8,19 @@
     "Program.fs"
   ],
   "frameworks": {
+    "netstandard1.5" : { 
+      "dependencies": {
+        "FsCheck":  { "version": "1.0.0", "type": "build" },
+        "Microsoft.NETCore.App": {
+        "type": "platform",
+        "version": "1.0.0-rc2-23925"
+        }
+      },
+      "imports": [
+        "portable-net45+win8",
+        "dnxcore50"
+      ]
+    },
     "net46" : {
       "dependencies": {
         "FsCheck":  { "version": "1.0.0", "type": "build" }

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -766,7 +766,7 @@ module Arb =
             |> convert (fun x -> x :> IDictionary<_,_>) (fun x -> x :?> Dictionary<_,_>)
 
         static member Culture() =
-#if PCL
+#if PCL || NETSTANDARD1_5
             let cultureNames = [
                 "af"; "af-ZA";
                 "am"; "am-ET";

--- a/src/FsCheck/NuGet.Config
+++ b/src/FsCheck/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/FsCheck/Program.fs
+++ b/src/FsCheck/Program.fs
@@ -1,0 +1,9 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv = 
+    printfn "Hello World!"
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/src/FsCheck/Program.fs
+++ b/src/FsCheck/Program.fs
@@ -1,9 +1,0 @@
-﻿// Learn more about F# at http://fsharp.org
-
-open System
-
-[<EntryPoint>]
-let main argv = 
-    printfn "Hello World!"
-    printfn "%A" argv
-    0 // return an integer exit code

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compilerName": "fsc",
+  "compileFiles": [
+    "Program.fs"
+  ],
+  "dependencies": {
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0-rc2-23925"
+    }
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": [
+        "portable-net45+win8",
+        "dnxcore50"
+      ]
+    }
+  }
+}

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -23,6 +23,7 @@
     "RunnerExtensions.fs"
   ],
   "frameworks": {
+    "net46": { },
     "netstandard1.5": {
       "dependencies": {
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -5,7 +5,6 @@
   },
   "compilerName": "fsc",
   "compileFiles": [
-    "Program.fs"
   ],
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -36,10 +36,7 @@
     "netstandard1.5": {
       "dependencies": {
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
-        "Microsoft.NETCore.App": {
-          "type": "platform",
-          "version": "1.0.0-rc2-23925"
-        }
+        "NETStandard.Library": "1.5.0-rc2-23925"
       },
       "imports": [
         "portable-net45+win8",

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -24,6 +24,9 @@
   ],
   "frameworks": {
     "net46": { 
+      "dependencies": {
+        "FSharp.Core": "4.0.0.1"
+      },
       "frameworkAssemblies": {
         "System": "",
         "System.Core": "",

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -4,6 +4,23 @@
   },
   "compilerName": "fsc",
   "compileFiles": [
+    "AssemblyInfo.fs",
+    "Common.fs",
+    "Random.fs",
+    "Reflect.fs",
+    "TypeClass.fs",
+    "Gen.fs",
+    "ReflectArbitrary.fs",
+    "Arbitrary.fs",
+    "ArbitraryExtensions.fs",
+    "GenExtensions.fs",
+    "Testable.fs",
+    "Prop.fs",
+    "PropExtensions.fs",
+    "Commands.fs",
+    "StateMachine.fs",
+    "Runner.fs",
+    "RunnerExtensions.fs"
   ],
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -23,7 +23,13 @@
     "RunnerExtensions.fs"
   ],
   "frameworks": {
-    "net46": { },
+    "net46": { 
+      "frameworkAssemblies": {
+        "System": "",
+        "System.Core": "",
+        "System.Numerics": ""
+      }
+    },
     "netstandard1.5": {
       "dependencies": {
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -22,15 +22,15 @@
     "Runner.fs",
     "RunnerExtensions.fs"
   ],
-  "dependencies": {
-    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc2-23925"
-    }
-  },
   "frameworks": {
     "netstandard1.5": {
+      "dependencies": {
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc2-23925"
+        }
+      },
       "imports": [
         "portable-net45+win8",
         "dnxcore50"

--- a/src/FsCheck/project.json
+++ b/src/FsCheck/project.json
@@ -1,7 +1,6 @@
 {
   "version": "1.0.0-*",
   "compilationOptions": {
-    "emitEntryPoint": true
   },
   "compilerName": "fsc",
   "compileFiles": [


### PR DESCRIPTION
ref #199 

- [X] add .NET Core `netstandard1.5` support using .NET CLI
- [X] add build in appveyor
- [ ] add build in travis
- [ ] use `dotnet mergenupkg` to add `netstandard1.5` to current `FsCheck` nupkg
- [ ] run command inside `build.fsx` using fake targets

To create the package:

```
dotnet restore
cd src\FsCheck
dotnet pack --configuration Release
```

this pr it's used in tutorial https://github.com/enricosada/fsharp-dotnet-cli-samples/wiki/Migrate-fsproj-To-.NET-CLI

The added test project is not needed, but is nice to check .net core.
It can be removed when xunit tests works
