### PR TITLE
Add Gen.shuffle

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -313,6 +313,17 @@ module Gen =
     [<CompiledName("ListOf")>]
     let listOfLength n arb = sequence [ for _ in 1..n -> arb ]
 
+    let shuffle xs =
+        gen {
+            let h = 922337203
+            let gn = choose (-h, h)
+            let! ns = listOfLength (Seq.length xs) gn
+            return xs
+                   |> Seq.zip ns
+                   |> Seq.sortBy fst
+                   |> Seq.map snd
+        }
+
     ///Tries to generate a value that satisfies a predicate. This function 'gives up' by generating None
     ///if the given original generator did not generate any values that satisfied the predicate, after trying to
     ///get values from by increasing its size.

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -313,6 +313,8 @@ module Gen =
     [<CompiledName("ListOf")>]
     let listOfLength n arb = sequence [ for _ in 1..n -> arb ]
 
+    ///Generates a random permutation of the given sequence.
+    //[category: Creating generators]
     [<CompiledName("Shuffle")>]
     let shuffle xs =
         gen {

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -313,18 +313,22 @@ module Gen =
     [<CompiledName("ListOf")>]
     let listOfLength n arb = sequence [ for _ in 1..n -> arb ]
 
-    ///Generates a random permutation of the given sequence.
+    ///Generates a random permutation of the given sequence using the Fisher-Yates shuffle algorithm.
     //[category: Creating generators]
     [<CompiledName("Shuffle")>]
     let shuffle xs =
+        let xs = xs |> Seq.toArray
+        let swap (arr : _ array) i j =
+            let v = arr.[j]
+            arr.[j] <- arr.[i]
+            arr.[i] <- v
         gen {
-            let h = 922337203
-            let gn = choose (-h, h)
-            let! ns = listOfLength (Seq.length xs) gn
-            return xs
-                   |> Seq.zip ns
-                   |> Seq.sortBy fst
-                   |> Seq.map snd
+            let copy = Array.copy xs
+            let maxI = copy.Length - 1
+            let! indexes = [ for i in 0..maxI - 1 -> choose (i, maxI) ]
+                           |> sequence
+            indexes |> List.iteri (swap copy)
+            return copy
         }
 
     ///Tries to generate a value that satisfies a predicate. This function 'gives up' by generating None

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -313,6 +313,7 @@ module Gen =
     [<CompiledName("ListOf")>]
     let listOfLength n arb = sequence [ for _ in 1..n -> arb ]
 
+    [<CompiledName("Shuffle")>]
     let shuffle xs =
         gen {
             let h = 922337203

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -120,11 +120,21 @@ module Gen =
         |> sample1
         |> ((=) (List.init length (fun _ -> v)))
 
+    // This property is non-deterministic, and may rarely fail. The chance of
+    // this property not holding in case of a uniform shuffle - in other words,
+    // the chance of producing 10 times the same input list of length 5 - is
+    // (1/5!)^10, which should be small enough.
+    // In this case, relying on the statistical attribute of a test being
+    // exceedingly unlikely to produce a False Positive is sometimes the only
+    // option. See also: https://github.com/fscheck/FsCheck/pull/221/
     [<Property>]
-    let Shuffle (NonEmptySet (xs:Set<int>)) =
-        Gen.shuffle xs
+    let Shuffle (s:Set<int>) =
+        s.Count > 1 ==> lazy
+        let l = Set.toList s
+        Gen.shuffle l
         |> sample 10
-        |> List.exists ((<>) (Set.toSeq xs))
+        |> List.map Seq.toList
+        |> List.exists ((<>) l)
    
     [<Property>]
     let SuchThatOption (v:int) (predicate:int -> bool) =

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -119,6 +119,12 @@ module Gen =
         Gen.listOfLength length (Gen.constant v)
         |> sample1
         |> ((=) (List.init length (fun _ -> v)))
+
+    [<Property>]
+    let Shuffle (NonEmptySet (xs:Set<int>)) =
+        Gen.shuffle xs
+        |> sample 10
+        |> List.forall ((<>) (Set.toSeq xs))
    
     [<Property>]
     let SuchThatOption (v:int) (predicate:int -> bool) =

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -124,7 +124,7 @@ module Gen =
     let Shuffle (NonEmptySet (xs:Set<int>)) =
         Gen.shuffle xs
         |> sample 10
-        |> List.forall ((<>) (Set.toSeq xs))
+        |> List.exists ((<>) (Set.toSeq xs))
    
     [<Property>]
     let SuchThatOption (v:int) (predicate:int -> bool) =


### PR DESCRIPTION
This Pull Request adds `shuffle` to the `Gen` module, as discussed in #220.

`shuffle` generates a random permutation of a given sequence, and has the type of

```
seq<'a> -> Gen<seq<'a>>
```

It has been ported from Haskell, where `shuffle` appeared in QuickCheck version 2.8.0 ([source](https://hackage.haskell.org/package/QuickCheck-2.8/docs/src/Test-QuickCheck-Gen.html#shuffle)) and got further optimized on version 2.8.2 ([source](https://github.com/nick8325/quickcheck/commit/6c360c1b594b0243e51bfcd4e2428882570e7a51)).