### PR TITLE
Generalize Gen.shuffle's documentation

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -313,10 +313,11 @@ module Gen =
     [<CompiledName("ListOf")>]
     let listOfLength n arb = sequence [ for _ in 1..n -> arb ]
 
-    ///Generates a random permutation of the given sequence using the Fisher-Yates shuffle algorithm.
+    ///Generates a random permutation of the given sequence.
     //[category: Creating generators]
     [<CompiledName("Shuffle")>]
     let shuffle xs =
+        // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
         let xs = xs |> Seq.toArray
         let swap (arr : _ array) i j =
             let v = arr.[j]


### PR DESCRIPTION
This PR removes from the documentation of `shuffle` the name of the underlying algorithm that's currently being used. Instead it adds a link to its description in the actual code.

As fairly [suggested](https://github.com/fscheck/FsCheck/pull/221/files/a9af0aecd97edb329a08a29b2f713bb8b776555f#r60366422) by @ploeh, the current algorithm is an implementation detail. In the future, it might be required to switch to a different one, and so that shouldn't be reflected in the documentation.