### PR TITLE
Added a property about Gen.shuffle.

### DIFF
--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -120,6 +120,13 @@ module Gen =
         |> sample1
         |> ((=) (List.init length (fun _ -> v)))
 
+    [<Property>]
+    let ``shuffle is isomorphic`` (xs : int array) =
+        Gen.shuffle xs
+        |> sample1
+        |> Array.sort
+        |> ((=) (Array.sort xs))
+
     // This property is non-deterministic, and may rarely fail. The chance of
     // this property not holding in case of a uniform shuffle - in other words,
     // the chance of producing 10 times the same input list of length 5 - is

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -121,7 +121,7 @@ module Gen =
         |> ((=) (List.init length (fun _ -> v)))
 
     [<Property>]
-    let ``shuffle is isomorphic`` (xs : int array) =
+    let ``shuffle generates a permutation`` (xs : int array) =
         Gen.shuffle xs
         |> sample1
         |> Array.sort


### PR DESCRIPTION
With the previous test suite, I could use the Devil's Advocate review
technique to reduce Gen.shuffle to this:

```F#
let shuffle (xs : 'a seq) = gen { return Array.empty<'a> }
```

Despite this degenerate, and obviously incorrect, implementation, all
tests passed. This demonstrated the need for more tests, so I added one.

I'm not 100% certain that the term 'isomorphic' entirely covers this
property, but if we regard the domain as an ordered collection of a
certain size, and the codomain as equal to the domain, then shuffle is
isomorphic because every element in the input is mapped to a position in
the output, and a reverse map exists.