### PR TITLE
StateMachine Shrinking shrinks Operations

### DIFF
--- a/src/FsCheck/StateMachine.fs
+++ b/src/FsCheck/StateMachine.fs
@@ -294,15 +294,14 @@ module StateMachine =
 //                seq { for i in 1..l.Length-1 do
 //                        yield! Seq.windowed i l //|> Seq.map Seq.toList
 //                }
-//
+////
 //            allSubsequences l |> Seq.distinct
 //
 //            let skipOne (l:list<_>) =
 //                seq { for i in 0..l.Length-1 do 
 //                        yield List.foldBack (fun e (c,r) -> c+1, if i <> c then e::r else r) l (0,[]) |> snd
-//                }
-            let defaultListShrinker = Arb.Default.FsList().Shrinker l
-            defaultListShrinker
+//                    }
+            l |> Arb.Default.FsList().Shrinker
 
         run.Operations 
         |> List.map fst

--- a/src/FsCheck/StateMachine.fs
+++ b/src/FsCheck/StateMachine.fs
@@ -2,7 +2,7 @@
 **  FsCheck                                                                 **
 **  Copyright (c) 2008-2015 Kurt Schelfthout and contributors.              **
 **  All rights reserved.                                                    **
-**  https://github.com/fscheck/FsCheck                              **
+**  https://github.com/fscheck/FsCheck                                      **
 **                                                                          **
 **  This software is released under the terms of the Revised BSD License.   **
 **  See the file License.txt for the full text.                             **
@@ -290,18 +290,19 @@ module StateMachine =
             //|> Seq.distinct
 
         let operationShrinker l =
-            let allSubsequences (l:list<_>) =
-                seq { for i in 1..l.Length-1 do
-                        yield! Seq.windowed i l //|> Seq.map Seq.toList
-                }
-
+//            let allSubsequences (l:list<_>) =
+//                seq { for i in 1..l.Length-1 do
+//                        yield! Seq.windowed i l //|> Seq.map Seq.toList
+//                }
+//
 //            allSubsequences l |> Seq.distinct
-
-            let skipOne (l:list<_>) =
-                seq { for i in 0..l.Length-1 do 
-                        yield List.foldBack (fun e (c,r) -> c+1, if i <> c then e::r else r) l (0,[]) |> snd
-                }
-            skipOne l
+//
+//            let skipOne (l:list<_>) =
+//                seq { for i in 0..l.Length-1 do 
+//                        yield List.foldBack (fun e (c,r) -> c+1, if i <> c then e::r else r) l (0,[]) |> snd
+//                }
+            let defaultListShrinker = Arb.Default.FsList().Shrinker l
+            defaultListShrinker
 
         run.Operations 
         |> List.map fst


### PR DESCRIPTION
Addresses #233

There are still two open issues:
1.) I am not entirely sure how I could write a testcase that checks if the Shrunk value is correct(3) and not 5. Of course it is possible to catch the exception and check the exception message but there should be a better way. Currently the testcase in the PR is just failing, so that needs to be fixed.

2.) Since I am using the defaultListShrinker again, I am not sure which implications this has. The testcase ``shrinker should remove loops`` still passes. Now and before it was not possible to have a transition sequence like [a->b;b->c] with an error in the state c shrunk to [a->c] in this testcase.