### PR TITLE
FsList shrinker

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -464,15 +464,12 @@ module Arb =
         static member FsList() = 
             { new Arbitrary<list<'a>>() with
                 override __.Generator = Gen.listOf generate
-                override __.Shrinker (l:'a list) =
-                    let rec inner cl pre = 
-                        match cl with
-                        | [] -> Seq.empty
-                        | [x] -> seq { yield pre; for x' in shrink x -> x'::pre |> List.rev}
-                        | x::xs -> seq { yield pre @ xs //skip current element
-                                         for x' in shrink x -> pre @ (x'::xs) //shrink current element
-                                         yield! inner xs (x::pre |> List.rev) }
-                    inner l []
+                override __.Shrinker l =
+                    match l with
+                    | [] ->         Seq.empty
+                    | (x::xs) ->    seq { yield xs
+                                          for xs' in shrink xs -> x::xs'
+                                          for x' in shrink x -> x'::xs }
             }
 
         ///Generate an object - a boxed char, string or boolean value.

--- a/src/FsCheck/StateMachine.fs
+++ b/src/FsCheck/StateMachine.fs
@@ -289,23 +289,9 @@ module StateMachine =
             |> Seq.choose (fun (_, op, Lazy model) -> op |> Option.map (fun op -> (op,model)))
             //|> Seq.distinct
 
-        let operationShrinker l =
-//            let allSubsequences (l:list<_>) =
-//                seq { for i in 1..l.Length-1 do
-//                        yield! Seq.windowed i l //|> Seq.map Seq.toList
-//                }
-////
-//            allSubsequences l |> Seq.distinct
-//
-//            let skipOne (l:list<_>) =
-//                seq { for i in 0..l.Length-1 do 
-//                        yield List.foldBack (fun e (c,r) -> c+1, if i <> c then e::r else r) l (0,[]) |> snd
-//                    }
-            l |> Arb.Default.FsList().Shrinker
-
         run.Operations 
         |> List.map fst
-        |> operationShrinker
+        |> Arb.Default.FsList().Shrinker
         //try to shrink the list of operations
         |> Seq.choose (fun operations -> 
                             let initialModel = fst run.Setup

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -349,6 +349,14 @@ module Arbitrary =
         List.exists (fun e -> e = int value) [0;1;2;3;4;5;6;7]
 
     [<Fact>]
+    let ``FsList shrunk is at minimum n-1``() =
+        let prop (l:int list) = 
+            let shrunk = Arb.Default.FsList().Shrinker l |> List.ofSeq
+            let result = l.Length = 0 || (shrunk |> Seq.forall (fun s -> s.Length = l.Length || s.Length = l.Length - 1))
+            result
+        Check.QuickThrowOnFailure prop
+
+    [<Fact>]
     let ``Generic List``() =
         generate<List<int>> |> sample 10 |> List.forall (fun _ -> true)
 


### PR DESCRIPTION
Following PR for #234

I did a performance comparison for three versions of the FsList shrinker:
1) old one
2)
```fsharp
        static member FsList() = 
            { new Arbitrary<list<'a>>() with
                override __.Generator = Gen.listOf generate
                override __.Shrinker (l:'a list) =
                    let skipOne (l:list<_>) =
                        seq { for i in 0..l.Length-1 do 
                              yield List.foldBack (fun e (c,r) -> c+1, if i <> c then e::r else r) l (0,[]) |> snd
                            }
                    let rec shrinks cl pre = 
                        match cl with
                        | [] -> Seq.empty
                        | [x] -> seq { for x' in shrink x -> x'::pre |> List.rev}
                        | x::xs -> seq { for x' in shrink x -> pre @ (x'::xs)
                                         yield! shrinks xs (x::pre |> List.rev) }
                    seq { yield! skipOne l; yield! shrinks l []}
```
3) the one in this PR

I did the performance check with three configurations. The small configuration uses startsize 0 and endsize 100 medium uses 200,200 and large uses 400,400. I ran each test 5 times and used the average. I did not use a stopwatch and simply looked at the time a testcase needed. The small configurations were quite similar due to the startup time of VS's test runner.
```fsharp
    [<Fact>]
    let ``performance_medium``() =
        let config = { Config.Quick with StartSize = 200; EndSize = 200 }
        let prop l = 
            let shrunk = Arb.Default.FsList().Shrinker l
            l.Length = 0 || (shrunk |> Seq.forall (fun s -> s.Length = l.Length || s.Length = l.Length - 1))
        Check.One(config, prop) 
```
Here are the results:
-- | ---S--- | --M-- | --L--
1 | 370ms | 5.5s | 40s
2 | 370ms | 2.8s | 19s
3 | 350ms | 2.0s | 14s

There is a difference between 3 and 1,2 we should consider. The shrunk values that skip one element are at the beginning of the sequence in 1 and 2. They are not in 3. It may make sense to use Implementation 2 if we want to have the skips at the beginning.