### PR TITLE
Changed Gen.listOf to stay below size in length.

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -382,9 +382,11 @@ module Gen =
     //[category: Creating generators from generators]
     [<CompiledName("ListOf")>]
     let listOf gn =
-        sized <| fun n ->
-            gen {   let! k = choose (0,n+1) //decrease chance of empty list
-                    return! listOfLength k gn }
+        sized <| fun n -> gen {
+            let! k = choose (min 1 n, n)
+            return! frequency [
+                (2 + n, listOfLength k gn); // 2 + n seems to give a good distribution of non-empty
+                (1    , gen.Return []) ] }  // vs empty lists
 
     /// Generates a non-empty list of random length. The maximum length 
     /// depends on the size parameter.

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -172,7 +172,7 @@ module Gen =
     let ListOf (NonNegativeInt size) (v:char) =
         Gen.resize size (Gen.listOf <| Gen.constant v)
         |> sample 10
-        |> List.forall (fun l -> l.Length <= size+1 && List.forall ((=) v) l)
+        |> List.forall (fun l -> l.Length <= size && List.forall ((=) v) l)
     
     [<Property>]
     let NonEmptyListOf (NonNegativeInt size) (v:string) =


### PR DESCRIPTION
Depending on your interpretation, this change could be considered a **breaking change**. Then again, perhaps it isn't :smile: Feel free to reject it if you disagree with this change. I actually started writing this up as an issue, but then went so deep into investigation and experimentation mode that I found it more appropriate to submit it as a pull request.

The previous version of `Gen.listOf` added 1 to the size in order to "decrease [the] chance of empty list". This had the peculiar effect that you'd see lists longer than `size`:

```
> [0..9] |> Gen.elements |> Gen.listOf |> Gen.sample 1 9;;
val it : int list list = [[4]; [9]; []; [7]; [0; 6]; [5]; [8]; [3]; []]
```

Notice the `[0; 6]` sample, which has a length of 2.

According to the documentation, this isn't wrong per se, since it only states that the "maximum length depends on the size parameter". Still, I found this unintuitive, and that it would make it harder to explain to beginners how FsCheck works.

For sizes from 1 to 10, the old implementation had these frequencies of empty lists:

```
Size  Empty lists
   1         42 %
   2         37 %
   3         32 %
   4         29 %
   5         26 %
   6         25 %
   7         23 %
   8         22 %
   9         21 %
  10         19 %
```

In the new implementation, I've fiddled a bit with the numbers to approximate something similar:

```
Size  Empty lists
   1         45 %
   2         37 %
   3         32 %
   4         29 %
   5         26 %
   6         24 %
   7         22 %
   8         21 %
   9         20 %
  10         18 %
```

As one can see, the new implementation creates empty lists with a slightly higher frequency for small sizes, but with lower frequencies as the size increases:

![image](https://cloud.githubusercontent.com/assets/242165/15159615/d21ffccc-16f5-11e6-8ae6-449f87be64cf.png)
