### PR TITLE
Added Gen.filter as an alias of Gen.suchThat.

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -376,6 +376,13 @@ module Gen =
     //[category: Creating generators from generators]
     [<CompiledName("Where");EditorBrowsable(EditorBrowsableState.Never)>]
     let where predicate generator = suchThat predicate generator
+    
+    ///Generates a value that satisfies a predicate. Contrary to suchThatOption, this function keeps re-trying
+    ///by increasing the size of the original generator ad infinitum.  Make sure there is a high probability that 
+    ///the predicate is satisfied.
+    //[category: Creating generators from generators]
+    [<CompiledName("Filter")>]
+    let filter = suchThat
 
     /// Generates a list of random length. The maximum length depends on the
     /// size parameter.


### PR DESCRIPTION
Many common monads have a 'filter' function. Examples include `List.filter`, `Map.filter`, `Set.filter`, `Option.filter`, and even `Arb.filter`. For the beginner, it's confusing that there's no `Gen.filter`; case in point: http://stackoverflow.com/q/37189368/126014

Even after I was able to localise `Gen.suchThat`, for a long time I was apprehensive of using it because I felt that I didn't sufficiently understand how it was different from a 'normal' filter function.

Since `Gen.filter` is simply a synonym for `Gen.suchThat`, I didn't add any tests. Likewise, there are no tests of `Gen.where`. I'll be happy to add a property for it, it this is wanted.