### PR TITLE
Added a note on using only finite sequences

### DIFF
--- a/docs/content/TestData.fsx
+++ b/docs/content/TestData.fsx
@@ -242,7 +242,8 @@ to be drawn from the collection:*)
 (***include-it:SkewedElementsExample***)
 
 (**The above examples all use `list` values as input, but you can use any `seq`
-expression, including `list` and `array` values.*)
+expression, including `list` and `array` values, as long as the sequence is
+finite. *)
 
 (**
     


### PR DESCRIPTION
to documentation example about Gen.elements.