### PR TITLE
Add generator for System.Net.IPAddress

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -11,6 +11,7 @@
 namespace FsCheck
 
 open System
+open System.Net
 
 ///Represents an int >= 0
 type NonNegativeInt = NonNegativeInt of int with
@@ -977,6 +978,15 @@ module Arb =
                 let! k = generate
                 return Guid((a: int),b,c,d,e,f,g,h,i,j,k)
             } |> fromGen
+
+#if PCL
+#else
+        static member IPAddress() =
+            let generator = generate |> Gen.arrayOfLength 4 |> Gen.map IPAddress
+            let shrinker (a:IPAddress) = a.GetAddressBytes() |> shrink |> Seq.filter (fun x -> Seq.length x = 4) |> Seq.map IPAddress
+        
+            fromGenShrink (generator, shrinker)
+#endif
 
         ///Arbitray instance for BigInteger.
         static member BigInt() =

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -9,6 +9,7 @@ module Arbitrary =
     open System
     open System.Globalization
     open System.Collections.Generic
+    open System.Net
     open Helpers
     open Arb
     open Swensen.Unquote
@@ -413,6 +414,17 @@ module Arbitrary =
     [<Fact>]
     let Guid () =
         generate<Guid> |> sample 10 |> ignore
+
+    [<Fact>]
+    let IPAddress () =
+        generate<IPAddress> |> sample 10 |> ignore
+
+    [<Property>]
+    let ``IPAddress shrinks`` (value: IPAddress) =
+        let bytesSum (x: IPAddress) = x.GetAddressBytes() |> Array.sumBy int
+
+        shrink value
+        |> Seq.forall (fun shrunkv -> bytesSum shrunkv = 0 || bytesSum shrunkv < bytesSum value)
 
     [<Property>]
     let Bigint (value:bigint) =


### PR DESCRIPTION
Add a generator for [`System.Net.Mail.IPAddress`](https://msdn.microsoft.com/en-us/library/system.net.ipaddress(v=vs.110).aspx). As this class is defined in `System.dll`, there are no additional dependencies.

The only thing noteworthy is that this class does not exist in any of the PCL targets, hence the `#if` clause.