### PR TITLE
Expanded examples for Gen.shuffle.

### DIFF
--- a/docs/content/TestData.fsx
+++ b/docs/content/TestData.fsx
@@ -250,22 +250,28 @@ finite.
 You can use the `Gen.shuffle` function to create a generator that generates a
 random permutation of a given finite sequence.
 
-In the following example, the numbers from 0 to 9 define the input sequence:*)
+In the following example, the
+[metasyntactic variables](https://en.wikipedia.org/wiki/Metasyntactic_variable)
+"foo", "bar", "baz", and "qux" define the input sequence:*)
 
 (***define-output:ShuffleExample***)
-Gen.shuffle [0..9] |> Gen.sample 0 1 |> List.head
+Gen.shuffle ["foo"; "bar"; "baz"; "qux"] |> Gen.sample 0 6
 
 (**Since `Gen.shuffle` doesn't rely on the `size` argument, it's `0` in this
 example, but any value would do; it wouldn't change the result.
 
-The result of this expression is a list of one sample, which is a random
-permutation of the input sequence:*)
+The result of this expression is a list of lists, where each list contains
+the original input list, but shuffled:*)
 
 (***include-it:ShuffleExample***)
 
-(**The above examples all use `list` values as input, but you can use any `seq`
+(**The above example uses a `list` value as input, but you can use any `seq`
 expression, including `list` and `array` values, as long as the sequence is
-finite. *)
+finite.
+
+All shuffles are equally likely; the input order isn't excluded, so the
+output may be the same as the input. Due to the nature of combinatorics, this
+is more likely to happen the smaller the input list is.*)
 
 (**
     


### PR DESCRIPTION
The previous documentation only showed a single example, which has some disadvantages.

First of all, the examples for `Gen.constant` and `Gen.elements` show more than one sample, so a reader already familiar with these examples will assume that this is the format used. Since the single example shown for `Gen.shuffle` was also a a list, a reader may be mislead to think that it works like `Gen.elements`.

Additionally, since the code examples documented are executed during generation of the documentation, the example values are random. Showing only a single example incurs the risk that the sample may look 'systematic' to the reader trying to understand what `Gen.shuffle` does. As an example, with the input list of `[0..9]`, there's a small risk that the generated sample is exactly `[0; 1; 2; 3; 4; 5; 6; 7; 8; 9]`. Not only that, but another 'systematic' sample value could be `[9; 8; 7; 6; 5; 4; 3; 2; 1; 0]`, `[0; 2; 4; 6; 8; 1; 3; 5; 7; 9]`, or any other value that the reader may interpret as looking 'deliberate'. Providing more than a single sample increases the chance of communicating to the reader how `Gen.shuffle` works.

In order to make the example easier to understand, I wanted an input list with fewer elements, so that it'd be easier for the reader to compare the input list with the generated samples. I considered [0..3], but then thought that the reader might then speculate about the choice of the number 3. In order to prevent that, I chose to use "foo", "bar", "baz", and "qux" instead.