### PR TITLE
Improve shrinker for IPAddress

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -983,7 +983,16 @@ module Arb =
 #else
         static member IPAddress() =
             let generator = generate |> Gen.arrayOfLength 4 |> Gen.map IPAddress
-            let shrinker (a:IPAddress) = a.GetAddressBytes() |> shrink |> Seq.filter (fun x -> Seq.length x = 4) |> Seq.map IPAddress
+            let shrinker (a:IPAddress) = 
+                let bytes = a.GetAddressBytes()
+
+                seq {
+                    for b0 in seq {yield bytes.[0]; yield! shrink bytes.[0]} do
+                    for b1 in seq {yield bytes.[1]; yield! shrink bytes.[1]} do
+                    for b2 in seq {yield bytes.[2]; yield! shrink bytes.[2]} do
+                    for b3 in seq {yield bytes.[3]; yield! shrink bytes.[3]} do
+                        yield IPAddress [|b0;b1;b2;b3|]
+                } |> Seq.skip 1
         
             fromGenShrink (generator, shrinker)
 #endif


### PR DESCRIPTION
A small improvement to the recent IPAddress Arb (thanks @ErikSchierboom !)
This shrinker avoids sequences that don't have 4 elements, also generates more coverage.

An example:
`FsCheck.Arb.Default.IPAddress().Shrinker(IPAddress.Parse "201.222.102.167") |> Seq.iter (printfn "%A")`

With the current shrinker this generates 31 values:

```
201.222.102.0
201.222.102.84
201.222.102.126
201.222.102.147
201.222.102.157
201.222.102.162
201.222.102.165
201.222.102.166
201.222.0.167
201.222.51.167
201.222.77.167
201.222.90.167
201.222.96.167
201.222.99.167
201.222.101.167
201.0.102.167
201.111.102.167
201.167.102.167
201.195.102.167
201.209.102.167
201.216.102.167
201.219.102.167
201.221.102.167
0.222.102.167
101.222.102.167
151.222.102.167
176.222.102.167
189.222.102.167
195.222.102.167
198.222.102.167
200.222.102.167
```

With the proposed shrinker it generates 5831 values (which isn't necessarily good for a shrinker) but it generates more "interesting" values like 201.222.0.0 (11th generated value), 201.0.0.0 (83rd position) and 0.0.0.0 (731st position).

There's lots of room for more improvement e.g. these mentioned values should come earlier.
