### PR TITLE
Behavior on unexpected input

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -202,11 +202,14 @@ module Gen =
 
     ///Build a generator that generates a value from one of the generators in the given non-empty seq, with
     ///given probabilities. The sum of the probabilities must be larger than zero.
+    ///<exception cref="System.ArgumentException">Thrown when the sum of the propabilites is smaller or equal 0.</exception>
     //[category: Creating generators from generators]
     [<CompiledName("Frequency")>]
     let frequency xs =
         let xs = Seq.toArray xs
         let tot = Array.sumBy fst xs
+        let throwIfInvalid = 
+            if tot <= 0 then invalidArg "xs" "Frequency was called with a sum of propabilites smaller or equal 0. No elements can be generated." 
         let rec pick i n =
             let k,x = xs.[i]
             if n<=k then x else pick (i+1) (n-k)

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -202,7 +202,7 @@ module Gen =
 
     ///Build a generator that generates a value from one of the generators in the given non-empty seq, with
     ///given probabilities. The sum of the probabilities must be larger than zero.
-    ///<exception cref="System.ArgumentException">Thrown if the sum of the probabilites is less than or equal to 0.</exception>
+    ///<exception cref="System.ArgumentException">Thrown if the sum of the probabilities is less than or equal to 0.</exception>
     //[category: Creating generators from generators]
     [<CompiledName("Frequency")>]
     let frequency xs =
@@ -212,7 +212,7 @@ module Gen =
             let k,x = xs.[i]
             if n<=k then x else pick (i+1) (n-k)
         if tot <= 0 then 
-            invalidArg "xs" "Frequency was called with a sum of probabilites less than or equal to 0. No elements can be generated."
+            invalidArg "xs" "Frequency was called with a sum of probabilities less than or equal to 0. No elements can be generated."
         else
             gen.Bind(choose (1,tot), pick 0)
 

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -202,18 +202,19 @@ module Gen =
 
     ///Build a generator that generates a value from one of the generators in the given non-empty seq, with
     ///given probabilities. The sum of the probabilities must be larger than zero.
-    ///<exception cref="System.ArgumentException">Thrown when the sum of the propabilites is smaller or equal 0.</exception>
+    ///<exception cref="System.ArgumentException">Thrown if the sum of the probabilites is less than or equal to 0.</exception>
     //[category: Creating generators from generators]
     [<CompiledName("Frequency")>]
     let frequency xs =
         let xs = Seq.toArray xs
         let tot = Array.sumBy fst xs
-        let throwIfInvalid = 
-            if tot <= 0 then invalidArg "xs" "Frequency was called with a sum of propabilites smaller or equal 0. No elements can be generated." 
         let rec pick i n =
             let k,x = xs.[i]
             if n<=k then x else pick (i+1) (n-k)
-        gen.Bind(choose (1,tot), pick 0)
+        if tot <= 0 then 
+            invalidArg "xs" "Frequency was called with a sum of probabilites less than or equal to 0. No elements can be generated."
+        else
+            gen.Bind(choose (1,tot), pick 0)
 
     let private frequencyOfWeighedSeq ws = 
         ws |> Seq.map (fun wv -> (wv.Weight, wv.Value)) |> frequency

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -64,6 +64,12 @@ module Gen =
                 |> Gen.frequency
                 |> sample 100
                 |> List.forall (isIn generatedValues)))
+
+    [<Fact>]
+    let ``frequency should realize if no element can be generated``() =
+        let prop = lazy (Gen.frequency [(0,Gen.constant 1)]) //used lazy since unqoute couldn't handle generator directly
+        raises<System.ArgumentException> <@ prop.Value @>
+        
     
     [<Property>]
     let Map (f:string -> int) v =

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -66,7 +66,7 @@ module Gen =
                 |> List.forall (isIn generatedValues)))
 
     [<Fact>]
-    let ``frequency should realize if no element can be generated``() =
+    let ``frequency should throw argument exception if no element can be generated``() =
         let prop = lazy (Gen.frequency [(0,Gen.constant 1)]) //used lazy since unqoute couldn't handle generator directly
         raises<System.ArgumentException> <@ prop.Value @>
         


### PR DESCRIPTION
PR for #252 

- [ ] No operation that satisfies the precondition could be generated.
- [ ] In Next no Operation is generated at all.
- [ ] Postcondition not satisfied.

I started with the second point. I realized that the problem can be tackled directly at the generators of the Gen module

Question is: should I add exception handling for the generators that might not work correctly if invalid input is specified? Seems like a big change if I do that. What do you think?