### PR TITLE
Fix Mono compilation errors

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -166,7 +166,7 @@ module Gen =
     //[category: Creating generators]
     [<CompiledName("Elements")>]
     let elements xs = 
-        choose (0, (Seq.length xs)-1) |> map (flip Seq.nth xs)
+        choose (0, (Seq.length xs)-1) |> map (flip Seq.item xs)
 
     [<CompiledName("GrowingElements")>]
     ///Build a generator that takes a non-empty sequence and randomly generates
@@ -514,7 +514,7 @@ module Gen =
                     counter := !counter + 1
                     !counter - 1
         let rec rands r0 = seq { let r1,r2 = split r0 in yield r1; yield! (rands r2) }
-        fun (v:'a) (Gen m:Gen<'b>) -> Gen (fun n r -> m n (Seq.nth ((mapToInt v)+1) (rands r)))
+        fun (v:'a) (Gen m:Gen<'b>) -> Gen (fun n r -> m n (Seq.item ((mapToInt v)+1) (rands r)))
 
 ///Operators for Gen.
 type Gen with


### PR DESCRIPTION
I was opening the `FsCheck-mono.sln` solution file in Xamarin Studio on my Mac, and found that the code did not compile. Both errors had the same cause: the deprecated `Seq.nth` was used instead of `Seq.item`:

![image](https://cloud.githubusercontent.com/assets/135246/15336048/f64a1fa4-1c74-11e6-9021-c4d40ce20ec9.png)

This PR fixes this.