### PR TITLE
Gen.eval uses size, instead of up to size.

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -141,20 +141,19 @@ module Gen =
     [<CompiledName("Resize")>]
     let resize newSize (Gen m) = Gen (fun _ r -> m newSize r)
 
-    ///Generates a value with maximum size n.
+    ///Generates a value of the give size with the given seed.
     //[category: Generating test values]
     [<CompiledName("Eval")>]
-    let eval n rnd (Gen m) = 
-        let size,rnd' = range (0,n) rnd
-        m size rnd'
+    let eval size seed (Gen m) =
+        m size seed
 
     ///Generates n values of the given size.
     //[category: Generating test values]
     [<CompiledName("Sample")>]
-    let sample size n gn  = 
+    let sample size n generator  = 
         let rec sample i seed samples =
             if i = 0 then samples
-            else sample (i-1) (Random.stdSplit seed |> snd) (eval size seed gn :: samples)
+            else sample (i-1) (Random.stdSplit seed |> snd) (eval size seed generator :: samples)
         sample n (Random.newSeed()) []
 
     ///Generates an integer between l and h, inclusive.
@@ -422,7 +421,7 @@ module Gen =
     [<CompiledName("ListOf")>]
     let listOf gn =
         sized <| fun n ->
-            gen {   let! k = choose (0,n+1) //decrease chance of empty list
+            gen {   let! k = choose (0,n)
                     return! listOfLength k gn }
 
     /// Generates a non-empty list of random length. The maximum length 

--- a/src/FsCheck/Script.fsx
+++ b/src/FsCheck/Script.fsx
@@ -7,6 +7,16 @@ open FsCheck
 open FsCheck.Experimental
 open System.Collections.Generic
 
+let l = Gen.listOf (Gen.constant 1)
+l 
+|> Gen.sample 10 1000
+|> Seq.map Seq.length 
+|> Seq.groupBy id 
+|> Seq.map (fun (l,gr) -> (l, Seq.length gr))
+|> Seq.sortBy fst
+|> Seq.toArray
+
+
 type Pid = int
 type Name = string
 type ProcessRegistry() =


### PR DESCRIPTION
This is discussed somewhat further in PR 241. The underlying issue is
that before this change, there was a bias to generate values of low
size. This is because in `Gen.eval`, which is also used by the runner directly
to evaluate a generator, a random size between 0 and the current test
size (which is set in configuration) is picked. This size is then passed
on to the generator. But, almost all generators that take size into account
themselves also pick a random size between 0 and the given size. So
overall, the size was skewed downward. This change addresses that by
changing eval to simply use the size as given. By default, FsCheck will
increase the size linearly from 1 to 100 over the course of the number
of tests is runs (also 100 by default).

I have also changed the `listOf` generator to now pick a size between
`0` and `n`, instead of `n+1` as that was a hack to decrease the chance
of generating quite so many empty lists - this should no longer be
necessary.