### PR TITLE
Renamed DontShrink to DoNotShrink,

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -103,7 +103,11 @@ type Function<'a,'b when 'a : comparison> = F of ref<list<('a*'b)>> * ('a ->'b) 
         F (table,fun x -> let y = f x in table := (x,y)::(!table); y)
 
 ///Use the generator for 'a, but don't shrink.
+[<Obsolete("Renamed to DoNotShrink.")>]
 type DontShrink<'a> = DontShrink of 'a
+
+///Use the generator for 'a, but don't shrink.
+type DoNotShrink<'a> = DoNotShrink of 'a
 
 ///Whereas most types are restricted by a size that grows
 ///as the test gets further, by applying this type the underlying
@@ -995,7 +999,7 @@ module Arb =
 
         ///Overrides the shrinker of any type to be empty, i.e. not to shrink at all.
         static member DontShrink() =
-            generate |> Gen.map DontShrink |> fromGen
+            generate |> Gen.map DoNotShrink |> fromGen
             
         ///Try to derive an arbitrary instance for the given type reflectively. 
         ///Generates and shrinks values for record, union, tuple and enum types.


### PR DESCRIPTION
since "dont" isn't an English word; "don't" is a proper contraction of "do
not", but the apostrophe is required. Omitting it is necessary in code,
but "Dont" looks wrong.

The .NET framework design guidelines are also clear on the subject:

"DO NOT use abbreviations or contractions as part of identifier names."

Source: https://msdn.microsoft.com/en-us/library/ms229045

---

This pull request is intended as a suggestion. I could also have submitted it as an issue for discussion, but I thought it was easier to demonstrate my intent by showing, with code, what I have in mind.

I deliberately kept the pull request as small as possible, so that it's easy to review and discuss. Additionally, it doesn't represent a lot of work on my part, so if we decide that this isn't a good idea after all, no one should feel bad for rejecting it.

Keeping the pull request small means that I have only addressed a single occurrence of _Dont_ in the code base. In other words, the suggested rename isn't consistently applied. Later commits can address that inconsistency, should we decide to move forward with this.

Other options for renaming could be:

- `SkipShrinking`
- `IgnoreShrinking`
- `OmitShrinking`
- `CancelShrinking`
- `DiscardShrinking`