### PR TITLE
Renamed last instance of DontShrink to DoNotShrink

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -998,7 +998,12 @@ module Arb =
             |> convert bigint int
 
         ///Overrides the shrinker of any type to be empty, i.e. not to shrink at all.
+        [<Obsolete("Renamed to DoNotShrink.")>]
         static member DontShrink() =
+            generate |> Gen.map DoNotShrink |> fromGen
+
+        ///Overrides the shrinker of any type to be empty, i.e. not to shrink at all.
+        static member DoNotShrink() =
             generate |> Gen.map DoNotShrink |> fromGen
             
         ///Try to derive an arbitrary instance for the given type reflectively. 


### PR DESCRIPTION
As a follow-up to #273, I'm submitting this very small pull request to complete the rename of `DontShrink` to `DoNotShrink`.

I've begun the work of renaming `DontSize` to `DoNotSize` as well, but it turns out to be slightly more complicated to do, so I thought it better to do that in a separate pull request.