### PR TITLE
Renamed DontSize to DoNotSize.

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -113,12 +113,12 @@ type DoNotShrink<'a> = DoNotShrink of 'a
 ///as the test gets further, by applying this type the underlying
 ///type will ignore this size and always generate from the full range.
 ///Note that this only makes a difference for types that have a range -
-///currently Int16, Int32, Int64 have DontSize Arbitrary instances.
+///currently Int16, Int32, Int64 have DoNotSize Arbitrary instances.
 ///This is typically (and at least currently) only applicable for value types
 ///that are comparable, hence the type constraints.
-type DontSize<'a when 'a : struct and 'a : comparison> = 
-    DontSize of 'a with
-    static member Unwrap(DontSize a) : 'a = a
+type DoNotSize<'a when 'a : struct and 'a : comparison> = 
+    DoNotSize of 'a with
+    static member Unwrap(DoNotSize a) : 'a = a
 
 [<AutoOpen>]
 module ArbPatterns =
@@ -298,13 +298,13 @@ module Arb =
         static member DontSizeInt16() =
             let gen = Gen.choose(int Int16.MinValue, int Int16.MaxValue)
             fromGenShrink(gen, shrink)
-            |> convert (int16 >> DontSize) (DontSize.Unwrap >> int)
+            |> convert (int16 >> DoNotSize) (DoNotSize.Unwrap >> int)
 
         ///Generate arbitrary int16 that is uniformly distributed in the whole range of int16 values.
         static member DoNotSizeInt16() =
             let gen = Gen.choose(int Int16.MinValue, int Int16.MaxValue)
             fromGenShrink(gen, shrink)
-            |> convert (int16 >> DontSize) (DontSize.Unwrap >> int)
+            |> convert (int16 >> DoNotSize) (DoNotSize.Unwrap >> int)
 
         ///Generate arbitrary uint16 that is between 0 and size.
         static member UInt16() =
@@ -316,13 +316,13 @@ module Arb =
         static member DontSizeUInt16() =
             let gen = Gen.choose(0, int UInt16.MaxValue)
             fromGenShrink(gen, shrink)
-            |> convert (uint16 >> DontSize) (DontSize.Unwrap >> int)
+            |> convert (uint16 >> DoNotSize) (DoNotSize.Unwrap >> int)
 
         ///Generate arbitrary uint16 that is uniformly distributed in the whole range of uint16 values.
         static member DoNotSizeUInt16() =
             let gen = Gen.choose(0, int UInt16.MaxValue)
             fromGenShrink(gen, shrink)
-            |> convert (uint16 >> DontSize) (DontSize.Unwrap >> int)
+            |> convert (uint16 >> DoNotSize) (DoNotSize.Unwrap >> int)
             
         ///Generate arbitrary int32 that is between -size and size.
         static member Int32() = 
@@ -335,20 +335,20 @@ module Arb =
             //let gen = Gen.choose(Int32.MinValue, Int32.MaxValue) doesn't work with random.fs, 
             //so using this trick instead
             let gen =
-                Gen.two generate<DontSize<int16>>
-                |> Gen.map (fun (DontSize h,DontSize l) -> int ((uint32 h <<< 16) ||| uint32 l))
+                Gen.two generate<DoNotSize<int16>>
+                |> Gen.map (fun (DoNotSize h,DoNotSize l) -> int ((uint32 h <<< 16) ||| uint32 l))
             fromGenShrink(gen, shrink)
-            |> convert DontSize DontSize.Unwrap
+            |> convert DoNotSize DoNotSize.Unwrap
 
         ///Generate arbitrary int32 that is between Int32.MinValue and Int32.MaxValue
         static member DoNotSizeInt32() =
             //let gen = Gen.choose(Int32.MinValue, Int32.MaxValue) doesn't work with random.fs, 
             //so using this trick instead
             let gen =
-                Gen.two generate<DontSize<int16>>
-                |> Gen.map (fun (DontSize h,DontSize l) -> int ((uint32 h <<< 16) ||| uint32 l))
+                Gen.two generate<DoNotSize<int16>>
+                |> Gen.map (fun (DoNotSize h,DoNotSize l) -> int ((uint32 h <<< 16) ||| uint32 l))
             fromGenShrink(gen, shrink)
-            |> convert DontSize DontSize.Unwrap
+            |> convert DoNotSize DoNotSize.Unwrap
 
         ///Generate arbitrary uint32 that is between 0 and size.
         static member UInt32() =
@@ -360,17 +360,17 @@ module Arb =
         static member DontSizeUInt32() =
             let gen = Gen.choose(0, int UInt32.MaxValue)
             fromGenShrink(gen, shrink)
-            |> convert (uint32 >> DontSize) (DontSize.Unwrap >> int)
+            |> convert (uint32 >> DoNotSize) (DoNotSize.Unwrap >> int)
 
         ///Generate arbitrary uint32 that is uniformly distributed in the whole range of uint32 values.
         static member DoNotSizeUInt32() =
             let gen = Gen.choose(0, int UInt32.MaxValue)
             fromGenShrink(gen, shrink)
-            |> convert (uint32 >> DontSize) (DontSize.Unwrap >> int)
+            |> convert (uint32 >> DoNotSize) (DoNotSize.Unwrap >> int)
 
         ///Generate arbitrary int64 that is between -size and size.
         ///Note that since the size is an int32, this does not actually cover the full
-        ///range of int64. See DontSize<int64> instead.
+        ///range of int64. See DoNotSize<int64> instead.
         static member Int64() =
             //we can be relaxed here, for the above reasons.
             from<int32>
@@ -380,18 +380,18 @@ module Arb =
         [<Obsolete("Renamed to DoNotSizeInt64.")>]
         static member DontSizeInt64() =
             let gen =
-                Gen.two generate<DontSize<int32>>
-                |> Gen.map (fun (DontSize h, DontSize l) -> (int64 h <<< 32) ||| int64 l)
+                Gen.two generate<DoNotSize<int32>>
+                |> Gen.map (fun (DoNotSize h, DoNotSize l) -> (int64 h <<< 32) ||| int64 l)
             fromGenShrink (gen,shrinkNumber)
-            |> convert DontSize DontSize.Unwrap
+            |> convert DoNotSize DoNotSize.Unwrap
 
         ///Generate arbitrary int64 between Int64.MinValue and Int64.MaxValue
         static member DoNotSizeInt64() =
             let gen =
-                Gen.two generate<DontSize<int32>>
-                |> Gen.map (fun (DontSize h, DontSize l) -> (int64 h <<< 32) ||| int64 l)
+                Gen.two generate<DoNotSize<int32>>
+                |> Gen.map (fun (DoNotSize h, DoNotSize l) -> (int64 h <<< 32) ||| int64 l)
             fromGenShrink (gen,shrinkNumber)
-            |> convert DontSize DontSize.Unwrap
+            |> convert DoNotSize DoNotSize.Unwrap
         
         ///Generate arbitrary uint64 that is between 0 and size.
         static member UInt64() =
@@ -402,18 +402,18 @@ module Arb =
         [<Obsolete("Renamed to DoNotSizeUInt64.")>]
         static member DontSizeUInt64() =
             let gen =
-                Gen.two generate<DontSize<uint32>>
-                |> Gen.map (fun (DontSize h, DontSize l) -> (uint64 h <<< 32) ||| uint64 l)
+                Gen.two generate<DoNotSize<uint32>>
+                |> Gen.map (fun (DoNotSize h, DoNotSize l) -> (uint64 h <<< 32) ||| uint64 l)
             fromGenShrink (gen,shrink)
-            |> convert DontSize DontSize.Unwrap
+            |> convert DoNotSize DoNotSize.Unwrap
         
         ///Generate arbitrary uint32 that is uniformly distributed in the whole range of uint32 values.
         static member DoNotSizeUInt64() =
             let gen =
-                Gen.two generate<DontSize<uint32>>
-                |> Gen.map (fun (DontSize h, DontSize l) -> (uint64 h <<< 32) ||| uint64 l)
+                Gen.two generate<DoNotSize<uint32>>
+                |> Gen.map (fun (DoNotSize h, DoNotSize l) -> (uint64 h <<< 32) ||| uint64 l)
             fromGenShrink (gen,shrink)
-            |> convert DontSize DontSize.Unwrap
+            |> convert DoNotSize DoNotSize.Unwrap
 
         ///Generates arbitrary floats, NaN, NegativeInfinity, PositiveInfinity, Maxvalue, MinValue, Epsilon included fairly frequently.
         static member Float() = 
@@ -709,7 +709,7 @@ module Arb =
 
         ///Generates an arbitrary TimeSpan. A TimeSpan is shrunk by removing days, hours, minutes, second and milliseconds.
         static member TimeSpan() =
-            let genTimeSpan = generate |> Gen.map (fun (DontSize ticks) -> TimeSpan ticks)
+            let genTimeSpan = generate |> Gen.map (fun (DoNotSize ticks) -> TimeSpan ticks)
             let shrink (t: TimeSpan) = 
                 if t.Days > 0 then
                     seq { yield TimeSpan(0, t.Hours, t.Minutes, t.Seconds, t.Milliseconds) }
@@ -1069,5 +1069,21 @@ module Arb =
                 override __.Shrinker a = ReflectArbitrary.reflectShrink getShrink a
             }
             
+// Compiler warning FS0044 occurs when a construct is deprecated.
+// This warning suppression has to sit in the end of the file, because once a
+// warning type is suppressed in a file, it can't be turned back on. There's a
+// feature request for that, though: 
+// https://fslang.uservoice.com/forums/245727-f-language/suggestions/6085102-allow-f-compiler-directives-like-nowarn-to-span
+#nowarn"44"
 
-    
+///Whereas most types are restricted by a size that grows
+///as the test gets further, by applying this type the underlying
+///type will ignore this size and always generate from the full range.
+///Note that this only makes a difference for types that have a range -
+///currently Int16, Int32, Int64 have DontSize Arbitrary instances.
+///This is typically (and at least currently) only applicable for value types
+///that are comparable, hence the type constraints.
+[<Obsolete("Renamed to DoNotSize.")>]
+type DontSize<'a when 'a : struct and 'a : comparison> = 
+    DontSize of 'a with
+    static member Unwrap(DontSize a) : 'a = a

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -34,10 +34,10 @@ module Arbitrary =
         ,   shrink<int16> v |> Seq.forall (fun shrunkv -> shrunkv <= abs v))
 
     [<Property>]
-    let DontSizeInt16 (DontSize v as dontSizeV) =
+    let DoNotSizeInt16 (DoNotSize v as doNotSizeV) =
         //could theoretically go wrong, if all the values do happen to be zero.
-        (   generate<DontSize<int16>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DontSize v) -> v <> 0s)
-        ,   shrink<DontSize<int16>> dontSizeV |> Seq.forall (fun (DontSize shrunkv) -> shrunkv <= abs v))
+        (   generate<DoNotSize<int16>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DoNotSize v) -> v <> 0s)
+        ,   shrink<DoNotSize<int16>> doNotSizeV |> Seq.forall (fun (DoNotSize shrunkv) -> shrunkv <= abs v))
 
     [<Property>]
     let UInt16 (NonNegativeInt size) (v:uint16) =
@@ -45,10 +45,10 @@ module Arbitrary =
         ,   shrink<uint16> v |> Seq.forall (fun shrunkv -> shrunkv <= v))
 
     [<Property>]
-    let DontSizeUInt16 (DontSize v as dontSizeV) =
+    let DoNotSizeUInt16 (DoNotSize v as doNotSizeV) =
         //could theoretically go wrong, if all the values do happen to be zero.
-        (   generate<DontSize<uint16>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DontSize v) -> v <> 0us)
-        ,   shrink<DontSize<uint16>> dontSizeV |> Seq.forall (fun (DontSize shrunkv) -> shrunkv <= v))
+        (   generate<DoNotSize<uint16>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DoNotSize v) -> v <> 0us)
+        ,   shrink<DoNotSize<uint16>> doNotSizeV |> Seq.forall (fun (DoNotSize shrunkv) -> shrunkv <= v))
 
     [<Property>]
     let Int32 (NonNegativeInt size) (v:int) =
@@ -56,10 +56,10 @@ module Arbitrary =
         ,   shrink<int> v |> Seq.forall (fun shrunkv -> shrunkv <= abs v))
 
     [<Property>]
-    let DontSizeInt32 (DontSize v as dontSizeV) =
+    let DoNotSizeInt32 (DoNotSize v as doNotSizeV) =
         //could theoretically go wrong, if all the values do happen to be zero.
-        (   generate<DontSize<int>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DontSize v) -> v <> 0)
-        ,   shrink<DontSize<int>> dontSizeV |> Seq.forall (fun (DontSize shrunkv) -> shrunkv <= abs v))
+        (   generate<DoNotSize<int>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DoNotSize v) -> v <> 0)
+        ,   shrink<DoNotSize<int>> doNotSizeV |> Seq.forall (fun (DoNotSize shrunkv) -> shrunkv <= abs v))
 
     [<Property>]
     let UInt32 (NonNegativeInt size) (v:uint32) =
@@ -67,10 +67,10 @@ module Arbitrary =
         ,   shrink<uint32> v |> Seq.forall (fun shrunkv -> shrunkv <= v))
 
     [<Property>]
-    let DontSizeUInt32 (DontSize v as dontSizeV) =
+    let DoNotSizeUInt32 (DoNotSize v as doNotSizeV) =
         //could theoretically go wrong, if all the values do happen to be zero.
-        (   generate<DontSize<uint32>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DontSize v) -> v <> 0u)
-        ,   shrink<DontSize<uint32>> dontSizeV |> Seq.forall (fun (DontSize shrunkv) -> shrunkv <= v))
+        (   generate<DoNotSize<uint32>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DoNotSize v) -> v <> 0u)
+        ,   shrink<DoNotSize<uint32>> doNotSizeV |> Seq.forall (fun (DoNotSize shrunkv) -> shrunkv <= v))
 
     [<Property>]
     let Int64 (NonNegativeInt size) (value: int64) = 
@@ -78,10 +78,10 @@ module Arbitrary =
         ,   shrink<int64> value |> Seq.forall (fun shrunkv -> (int shrunkv) <= abs (int value)))
                 
     [<Property>]
-    let DontSizeInt64 (DontSize v as dontSizeV) =
+    let DoNotSizeInt64 (DoNotSize v as doNotSizeV) =
         //could theoretically go wrong, if all the values do happen to be zero.
-        (   generate<DontSize<int64>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DontSize v) -> v <> 0L)
-        ,   shrink<DontSize<int64>> dontSizeV |> Seq.forall (fun (DontSize shrunkv) -> shrunkv <= abs v))
+        (   generate<DoNotSize<int64>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DoNotSize v) -> v <> 0L)
+        ,   shrink<DoNotSize<int64>> doNotSizeV |> Seq.forall (fun (DoNotSize shrunkv) -> shrunkv <= abs v))
 
     [<Property>]
     let UInt64 (NonNegativeInt size) (v:uint64) =
@@ -89,10 +89,10 @@ module Arbitrary =
         ,   shrink<uint64> v |> Seq.forall (fun shrunkv -> shrunkv <= v))
 
     [<Property>]
-    let DontSizeUInt64 (DontSize v as dontSizeV) =
+    let DoNotSizeUInt64 (DoNotSize v as doNotSizeV) =
         //could theoretically go wrong, if all the values do happen to be zero.
-        (   generate<DontSize<uint64>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DontSize v) -> v <> 0UL)
-        ,   shrink<DontSize<uint64>> dontSizeV |> Seq.forall (fun (DontSize shrunkv) -> shrunkv <= v))
+        (   generate<DoNotSize<uint64>> |> Gen.resize 0 |> sample 100 |> List.exists (fun (DoNotSize v) -> v <> 0UL)
+        ,   shrink<DoNotSize<uint64>> doNotSizeV |> Seq.forall (fun (DoNotSize shrunkv) -> shrunkv <= v))
 
     [<Property>]
     let Double (NonNegativeInt size) (value:float) =


### PR DESCRIPTION
Turned out that this wasn't quite as bad as I feared. Stil, there's a few lines to review.

Notice that I had to move the old `DontSize` type to the bottom of the file.