### PR TITLE
Emit debug info for compiled lambda Expression

### DIFF
--- a/src/FsCheck/Reflect.fs
+++ b/src/FsCheck/Reflect.fs
@@ -66,7 +66,15 @@ module internal Reflect =
                                                       :> Expression)
         let body  = Expression.New (ctor, pars)
         let l     = Expression.Lambda<Func<obj[], obj>> (body, par)
-        let f     = l.Compile ()
+
+        let f     =
+#if PCL
+            l.Compile ()
+#else
+            let debugInfoGen = System.Runtime.CompilerServices.DebugInfoGenerator.CreatePdbGenerator ()
+            l.Compile (debugInfoGen)
+#endif
+
         f.Invoke
 
     /// Returns the case name, type, and functions that will construct a constructor and a reader of a union type respectively


### PR DESCRIPTION
I recently upgraded a test project from an older version of FsCheck to the current version and found that dotCover seems to have a problem collecting test coverage information after the upgrade. I searched JetBrains' support site and found there's a known (and expected) issue when generating code at run-time without emitting debug information (i.e., a PDB).

I've made a small change (for non-portable targets only) to use the ``Expression.Compile(DebugInfoGenerator)`` overload to emit debugging information. I haven't tested it yet, but I don't think the change will have any negative impact -- I'm able to build and run FsCheck (including this change) without any issues. I'll try to test the change within the next few days to confirm it has the expected effect of allowing dotCover to collect coverage data for FsCheck-based tests.