### PR TITLE
Eliminate tuple allocations in splittable-RNG functions.

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -15,7 +15,7 @@ type internal IGen =
     
 ///Generator of a random value, based on a size parameter and a randomly generated int.
 and [<NoEquality;NoComparison>] Gen<'a> = 
-    private Gen of (int -> Random.Rnd -> 'a * Random.Rnd)
+    private Gen of (int -> Rnd -> 'a * Rnd)
         ///map the given function to the value in the generator, yielding a new generator of the result type.
         member internal x.Map<'a,'b> (f: 'a -> 'b) : Gen<'b> = match x with (Gen g) -> Gen (fun n r -> let s,r =  g n r in f s,r)
     interface IGen with
@@ -112,7 +112,6 @@ type WeightAndValue<'a> =
 module Gen =
 
     open Common
-    open Random
     open System
     open System.Collections.Generic
     open System.ComponentModel
@@ -142,7 +141,7 @@ module Gen =
     //[category: Generating test values]
     [<CompiledName("Eval")>]
     let eval n rnd (Gen m) = 
-        let size,rnd' = rangeInt (0,n) rnd
+        let size,rnd' = Random.rangeInt (0, n, rnd)
         m size rnd' |> fst
 
     ///Generates n values of the given size.
@@ -157,7 +156,7 @@ module Gen =
     ///Generates an integer between l and h, inclusive.
     //[category: Creating generators]
     [<CompiledName("Choose")>]
-    let choose (l,h) = Gen (fun _ r -> Random.rangeInt (l,h) r) 
+    let choose (l,h) = Gen (fun _ r -> Random.rangeInt (l,h,r))
 
     ///Build a generator that randomly generates one of the values in the given non-empty seq.
     //[category: Creating generators]
@@ -468,7 +467,7 @@ module Gen =
                     toCounter.Add(value,!counter)
                     counter := !counter + 1
                     !counter - 1
-        let rec rands r0 = seq { let r1,r2 = split r0 in yield r1; yield! (rands r2) }
+        let rec rands r0 = seq { let r1,r2 = Random.split r0 in yield r1; yield! (rands r2) }
         Gen (fun n r -> m n (Seq.nth ((mapToInt v)+1) (rands r)))
 
 ///Operators for Gen.

--- a/src/FsCheck/Random.fs
+++ b/src/FsCheck/Random.fs
@@ -26,146 +26,179 @@ all the functions are pure and the state is carried explicitly using the type Rn
 This approach fits better with how FsCheck Generators work.
 *)
 
-module Random =
+open System.Runtime.InteropServices
 
-    let [<Literal>] private GOLDEN_GAMMA = 0x9e3779b97f4a7c15UL // must be an odd number
+module private RandomConstants =
+
+    let [<Literal>] GOLDEN_GAMMA = 0x9e3779b97f4a7c15UL // must be an odd number
 
     //the positive difference between 1.0 and the smallest double value > 1.0
-    let [<Literal>] private DOUBLE_MULTIPLIER = 1.1102230246251565e-016 // 1.0 / double (1L <<< 53)
-  
-    [<Struct>]
-    type Rnd = 
-        val Seed: uint64
-        val Gamma: uint64 //an odd integer
-        new(seed, gamma) = { Seed = seed; Gamma = gamma }
-        override t.ToString() = sprintf "%i,%i" t.Seed t.Gamma
-                         
-    let private next (state:Rnd) = 
-        Rnd(state.Seed + state.Gamma, state.Gamma)
-    
-    let private mix64 z =
+    let [<Literal>] DOUBLE_MULTIPLIER = 1.1102230246251565e-016 // 1.0 / double (1L <<< 53)
+
+[<Struct>]
+type Rnd =
+    /// Seed value for the random number generator.
+    val Seed: uint64
+    /// An odd integer
+    val Gamma: uint64
+
+    /// Create a new random number generator with the given seed and gamma.
+    /// Useful to faithfully reproduce a sequence or part of it. gamma must be odd,
+    /// or this throws invalid argument exception. For good pseudo-random properties,
+    /// please only use seeds and gamma that were generated as part of a sequence
+    /// started with the default create function.
+    new(seed, gamma) =
+        if (gamma % 2UL = 0UL) then
+            invalidArg "gamma" "Gamma must be odd."
+
+        { Seed = seed; Gamma = gamma }
+
+    /// Create a new Rnd value with the specified seed value and the 'golden' gamma.
+    new(seed) = { Seed = seed; Gamma = RandomConstants.GOLDEN_GAMMA }
+
+    member internal this.Next () =
+        Rnd (this.Seed + this.Gamma, this.Gamma)
+
+    static member internal mix64 z =
         let z = (z ^^^ (z >>> 33)) * 0xff51afd7ed558ccdUL
         let z = (z ^^^ (z >>> 33)) * 0xc4ceb9fe1a85ec53UL
         z ^^^ (z >>> 33)
 
-    let private mix32variant04 z =
+    static member internal mix32variant04 z =
         let z = (z ^^^ (z >>> 33)) * 0x62a9d9ed799705f5UL
         int (((z ^^^ (z >>> 28)) * 0xcb24d0a5c88c35b3UL) >>> 32)
 
-    let private mix64variant13 z =
+    static member internal mix64variant13 z =
         let z = (z ^^^ (z >>> 30)) * 0xbf58476d1ce4e5b9UL
         let z = (z ^^^ (z >>> 27)) * 0x94d049bb133111ebUL
         z ^^^ (z >>> 31)
 
-    let private bitCount i =
+    static member internal bitCount i =
         let i = i - ((i >>> 1) &&& 0x5555555555555555UL)
         let i = (i &&& 0x3333333333333333UL) + ((i >>> 2) &&& 0x3333333333333333UL)
         (((i + (i >>> 4)) &&& 0xF0F0F0F0F0F0F0FUL) * 0x101010101010101UL) >>> 56
 
-    let private mixGamma z =
-        let z = (mix64 z) ||| 1UL //make odd
-        let n = bitCount (z ^^^ (z >>> 1))
+    static member internal mixGamma z =
+        let z = (Rnd.mix64 z) ||| 1UL //make odd
+        let n = Rnd.bitCount (z ^^^ (z >>> 1))
         //Fig 16 in the paper contains a bug here - it does n >= 24.
         if (n < 24UL) then z ^^^ 0xaaaaaaaaaaaaaaaaUL else z //This result is always odd.
 
-    let private defaultGen = System.DateTime.Now.Ticks |> uint64 |> mix64variant13 |> ref
+    override t.ToString() = sprintf "%i,%i" t.Seed t.Gamma
+
+
+//
+[<AbstractClass; Sealed>]
+type Random () =
+    static let defaultGen = System.DateTime.UtcNow.Ticks |> uint64 |> Rnd.mix64variant13 |> ref
+
+    static member DefaultGen = defaultGen
 
     ///Create a new random number generator with the given seed and a "golden" gamma.
-    let createWithSeed seed =
-        Rnd(seed, GOLDEN_GAMMA)
+    static member createWithSeed seed =
+        Rnd(seed)
 
     ///Create a new random number generator with the given seed and gamma. Useful to faithfully reproduce a sequence
     ///or part of it. gamma must be odd, or this throws invalid argument exception. For good pseudo-random properties,
     ///please only use seeds and gamma that were generated as part of a sequence started with the default create function.
-    let createWithSeedAndGamma (seed, gamma) =
-        if (gamma % 2UL = 0UL) then invalidArg "gamma" "Gamma must be odd."
+    static member createWithSeedAndGamma (seed, gamma) =
         Rnd(seed, gamma)
 
     ///Create a new random number generator that goes through some effort to generate a new seed
     ///every time it's called, and also to generate different seeds on different machines, though
     ///the latter is not at all guaranteed.
-    let create() =
-        let s = lock defaultGen (fun () -> let r = !defaultGen in defaultGen := r + 2UL * GOLDEN_GAMMA; r)
-        Rnd(mix64variant13 s, mixGamma(s + GOLDEN_GAMMA))
+    static member create() =
+        let s = lock defaultGen <| fun () ->
+            let r = !defaultGen
+            defaultGen := r + 2UL * RandomConstants.GOLDEN_GAMMA
+            r
 
-    let private nextUInt64 s =
-        let s' = next s
-        mix64variant13 s'.Seed, s'
+        Rnd(Rnd.mix64variant13 s, Rnd.mixGamma(s + RandomConstants.GOLDEN_GAMMA))
+
+    ///Generate the next pseudo-random uint64 in the sequence, and return the new Rnd.
+    static member private nextUInt64 (s : Rnd, [<Out>] s' : byref<Rnd>) =
+        s' <- s.Next()
+        Rnd.mix64variant13 s'.Seed
 
     ///Generate the next pseudo-random int64 in the sequence, and return the new Rnd.
-    let nextInt64 s =
-        let s' = next s
-        int64 <| mix64variant13 s'.Seed, s'
+    static member nextInt64 (s : Rnd, [<Out>] s' : byref<Rnd>) =
+        s' <- s.Next()
+        int64 <| Rnd.mix64variant13 s'.Seed
 
     ///Generate the next pseudo-random int in the sequence, and return the new Rnd.
-    let nextInt s =
-        let s' = next s
-        mix32variant04 s'.Seed, s'
+    static member nextInt (s : Rnd, [<Out>] s' : byref<Rnd>) =
+        s' <- s.Next()
+        Rnd.mix32variant04 s'.Seed
 
     ///Generate the next pseudo-random float in the sequence in the interval [0, 1[ and return the new Rnd.
-    let nextFloat s =
-        let l,s' = nextUInt64 s
-        double (l >>> 11) * DOUBLE_MULTIPLIER, s'
+    static member nextFloat (s : Rnd, [<Out>] s' : byref<Rnd>) =
+        let l = Random.nextUInt64 (s, &s')
+        double (l >>> 11) * RandomConstants.DOUBLE_MULTIPLIER
 
     ///Split this PRNG in two PRNGs that overlap with very small probability.
-    let split s0 =
-        let s1 = next s0
-        let s2 = next s1
-        s2, Rnd(mix64variant13 s1.Seed, mixGamma s2.Seed)
+    static member split (state : Rnd, [<Out>] left : byref<Rnd>, [<Out>] right : byref<Rnd>) : unit =
+        let s1 = state.Next ()
+        let s2 = s1.Next ()
+        left <- s2
+        right <- Rnd(Rnd.mix64variant13 s1.Seed, Rnd.mixGamma s2.Seed)
 
     ///Generate the next pseudo-random int64 in the given range (inclusive l and h) and return the new Rnd.
-    let rec rangeInt64 (l,h) s =
+    static member rangeInt64 (l, h, s : Rnd, [<Out>] s' : byref<Rnd>) =
         if l > h then //swap l and h
-            rangeInt64 (h,l) s
+            Random.rangeInt64 (h, l, s, &s')
         else
-            let maybeResult = nextInt64 s
             let m = h - l  //size of the exclusive range
             let n = m + 1L //size of the inclusive range
+            let mutable candidate = Random.nextInt64 (s, &s')
+            let mutable result = System.Nullable<_> ()
             if (n > 0L) then
                 //we have a range that is a positive int64, i.e. a "small" range relative to the total range - half of it or less.
                 //So we need to be a bit smart on how to find an int64 in that range.
-                let rec iter (cand,s) =
+                while not result.HasValue do
                     //since the range is half or less, we create a positive int64 by shifting right.
-                    let pcand = int64 (uint64 cand >>> 1)
+                    let pcand = int64 (uint64 candidate >>> 1)
                     //a good candidate offset from l, i.e. offset < n.
                     let offset = pcand % n
                     //
                     if pcand + m - offset < 0L then
-                        iter (nextInt64 s)
+                        candidate <- Random.nextInt64 (s, &s')
                     else
-                        l + offset, s
-                iter maybeResult
+                        result <- System.Nullable<_> (l + offset)
             else 
                 //we have a range that is a negative int64, i.e. h -l overflowed and so we have "large" range - more than half the total range.
                 //we can just keep generating until we find a number in the desired range.
-                let rec iter (cand, s) =
-                    if cand < l || cand >= h then 
-                        iter (nextInt64 s)
+                while not result.HasValue do
+                    if candidate < l || candidate >= h then
+                        candidate <- Random.nextInt64 (s, &s')
                     else
-                        cand, s
-                iter maybeResult
+                        result <- System.Nullable<_> (candidate)
+            
+            // Return the result
+            result.Value
 
     ///Generate the next pseudo-random int in the given range (inclusive l and h) and returns the new Rnd.
-    let rec rangeInt (l,h) s =
+    static member rangeInt (l, h, s : Rnd, [<Out>] s' : byref<Rnd>) : int =
         if l > h then
-            rangeInt (h,l) s
+            Random.rangeInt (h, l, s, &s')
         else
-            let maybeResult = nextInt s
             let m = h - l
             let n = m + 1
+            let mutable candidate = Random.nextInt (s, &s')
+            let mutable result = System.Nullable<_> ()
             if (n > 0) then
-                let rec iter (cand,s) =
-                    let pcand = int (uint32 cand >>> 1)
+                while not result.HasValue do
+                    let pcand = int (uint32 candidate >>> 1)
                     let offset = pcand % n
                     if pcand + m - offset < 0 then
-                        iter (nextInt s)
+                        candidate <- Random.nextInt (s, &s')
                     else
-                        l + offset, s
-                iter maybeResult
+                        result <- System.Nullable<_> (l + offset)
             else 
-                let rec iter (cand, s) =
-                    if cand < l || cand >= h then 
-                        iter (nextInt s)
+                while not result.HasValue do
+                    if candidate < l || candidate >= h then 
+                        candidate <- Random.nextInt (s, &s')
                     else
-                        cand, s
-                iter maybeResult
+                        result <- System.Nullable<_> (candidate)
+
+            // Return the result.
+            result.Value

--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -28,7 +28,7 @@ type TestResult =
                 * list<obj>(*the original arguments that produced the failed test*)
                 * list<obj>(*the shrunk arguments that produce a failed test*)
                 * Outcome(*possibly exception or timeout that falsified the property*) 
-                * Random.Rnd (*the seed used*)
+                * Rnd (*the seed used*)
     | Exhausted of TestData
 
 
@@ -51,7 +51,7 @@ type Config =
       ///The maximum number of tests where values are rejected, e.g. as the result of ==>
       MaxFail       : int
       ///If set, the seed to use to start testing. Allows reproduction of previous runs.
-      Replay        : Random.Rnd option
+      Replay        : Rnd option
       ///Name of the test.
       Name          : string
       ///The size to use for the first test.

--- a/src/FsCheck/Testable.fs
+++ b/src/FsCheck/Testable.fs
@@ -149,7 +149,7 @@ module private Testable =
 
     let private shrinking shrink x pf =
         let promoteRose (m:Rose<Gen<_>>) : Gen<Rose<_>> = 
-            Gen (fun s r -> let mr = Rose.map (fun (Gen m') -> m' s r |> fst) m in (mr,r))
+            Gen (fun s r -> let mr = Rose.map (fun (Gen m') -> (m' s r).Value) m in GeneratedValue (mr,r))
         //cache is important here to avoid re-evaluation of property
         let rec props x = MkRose (lazy (property (pf x) |> Property.GetGen), shrink x |> Seq.map props |> Seq.cache)
         promoteRose (props x)
@@ -195,7 +195,7 @@ module private Testable =
             { new Testable<Lazy<'a>> with
                 member __.Property b =
                     let promoteLazy (m:Lazy<_>) = 
-                        Gen (fun s r -> (Rose.join <| Rose.ofLazy (lazy (match m.Value with (Gen g) -> g s r |> fst))), r)
+                        Gen (fun s r -> GeneratedValue ((Rose.join <| Rose.ofLazy (lazy (match m.Value with (Gen g) -> (g s r).Value))), r))
                     promoteLazy (lazy (Prop.safeForce b |> Property.GetGen)) |> Property } 
         static member Result() =
             { new Testable<Result> with

--- a/tests/FsCheck.Test/Random.fs
+++ b/tests/FsCheck.Test/Random.fs
@@ -6,7 +6,6 @@ module Random =
     open Xunit
     open FsCheck
     open FsCheck.Xunit
-    open FsCheck.Random
 
     
     [<Property>]


### PR DESCRIPTION
These changes move the Rnd struct out into the FsCheck namespace and
moved the mixing functions from the Random module into members of the
Rnd struct. The Random module was converted into a static class and the
functions converted to static methods. These methods have been modified
to use 'out' parameters to return the updated Rnd value instead of
returning it with the generated random value in a tuple, thus
eliminating a large source of temporary allocations when running
FsCheck tests (which caused slowdowns due to GC).