### PR TITLE
Prop.Classify

### DIFF
--- a/src/FsCheck/Common.fs
+++ b/src/FsCheck/Common.fs
@@ -49,3 +49,24 @@ module internal Common =
 
     let (|MapContains|_|) key value =
         Map.tryFind key value
+
+
+    // The following function is taken from Tomas Petricek's stackoverflow answer:
+    // http://stackoverflow.com/a/12564899/2219351
+    /// Returns a sequence that, when iterated, 
+    /// yields elements of the underlying sequence while the given predicate returns true, 
+    /// and then returns the last element, but none further.
+    let takeWhilePlusLast predicate (s:seq<_>) = 
+        /// Iterates over the enumerator, yielding elements and
+        /// stops after an element for which the predicate does not hold
+        let rec loop (en:System.Collections.Generic.IEnumerator<_>) = seq {
+            if en.MoveNext() then
+                // Always yield the current, stop if predicate does not hold
+                yield en.Current
+            if predicate en.Current then
+                yield! loop en }
+
+        // Get enumerator of the sequence and yield all results
+        // (making sure that the enumerator gets disposed)
+        seq { use en = s.GetEnumerator()
+            yield! loop en }

--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -161,7 +161,7 @@ module Runner =
         let seed = match config.Replay with None -> newSeed() | Some s -> s
         let increaseSizeStep = float (config.EndSize - config.StartSize) / float config.MaxTest
         test (float config.StartSize) ((+) increaseSizeStep) seed (property prop |> Property.GetGen) 
-        |> Seq.takeWhile (fun step ->
+        |> Common.takeWhilePlusLast (fun step ->
             lastStep := step
             //printfn "%A" step
             match step with


### PR DESCRIPTION
PR related to #283 

`Prop.Classify` did not classify the last element:
Reason:
`takeWhile `does not include the element which does not satisfy the
predicate.
Therefore, changed `takeWhile `to a custom implementation

I added the implementation to the Common module. Not sure if it belongs here.
The solution was taken from a stackoverflow answer
http://stackoverflow.com/a/12564899/2219351