### PR TITLE
Move PCL-specific culture names to Data module

### DIFF
--- a/src/FsCheck.Portable.Profile259/FsCheck.Portable.Profile259.fsproj
+++ b/src/FsCheck.Portable.Profile259/FsCheck.Portable.Profile259.fsproj
@@ -50,6 +50,9 @@
     <Compile Include="..\FsCheck\Common.fs">
       <Link>Common.fs</Link>
     </Compile>
+    <Compile Include="..\FsCheck\Data.fs">
+      <Link>Data.fs</Link>
+    </Compile>
     <Compile Include="..\FsCheck\Random.fs">
       <Link>Random.fs</Link>
     </Compile>

--- a/src/FsCheck.Portable.Profile7/FsCheck.Portable.Profile7.fsproj
+++ b/src/FsCheck.Portable.Profile7/FsCheck.Portable.Profile7.fsproj
@@ -50,6 +50,9 @@
     <Compile Include="..\FsCheck\Common.fs">
       <Link>Common.fs</Link>
     </Compile>
+    <Compile Include="..\FsCheck\Data.fs">
+      <Link>Data.fs</Link>
+    </Compile>
     <Compile Include="..\FsCheck\Random.fs">
       <Link>Random.fs</Link>
     </Compile>

--- a/src/FsCheck.Portable.Profile78/FsCheck.Portable.Profile78.fsproj
+++ b/src/FsCheck.Portable.Profile78/FsCheck.Portable.Profile78.fsproj
@@ -50,6 +50,9 @@
     <Compile Include="..\FsCheck\Common.fs">
       <Link>Common.fs</Link>
     </Compile>
+    <Compile Include="..\FsCheck\Data.fs">
+      <Link>Data.fs</Link>
+    </Compile>
     <Compile Include="..\FsCheck\Random.fs">
       <Link>Random.fs</Link>
     </Compile>

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -137,11 +137,7 @@ module Arb =
     open TypeClass    
     open System.ComponentModel
     open System.Threading
-
-#if PCL
-#else
     open Data
-#endif
 
     [<AbstractClass;Sealed>]
     type Default = class end
@@ -867,124 +863,7 @@ module Arb =
             |> convert (fun x -> x :> IDictionary<_,_>) (fun x -> x :?> Dictionary<_,_>)
 
         static member Culture() =
-#if PCL
-            let cultureNames = [
-                "af"; "af-ZA";
-                "am"; "am-ET";
-                "ar"; "ar-AE"; "ar-BH"; "ar-DZ"; "ar-EG"; "ar-IQ"; "ar-JO"; "ar-KW"; "ar-LB"; "ar-LY"; "ar-MA"; "ar-OM"; "ar-QA"; "ar-SA"; "ar-SY"; "ar-TN"; "ar-YE"; "arn"; "arn-CL";
-                "as"; "as-IN";
-                "az"; "az-Cyrl"; "az-Cyrl-AZ"; "az-Latn"; "az-Latn-AZ";
-                "ba"; "ba-RU";
-                "be"; "be-BY";
-                "bg"; "bg-BG";
-                "bn"; "bn-BD"; "bn-IN";
-                "bo"; "bo-CN";
-                "br"; "br-FR";
-                "bs"; "bs-Cyrl"; "bs-Cyrl-BA"; "bs-Latn"; "bs-Latn-BA";
-                "ca"; "ca-ES";
-                "co"; "co-FR";
-                "cs"; "cs-CZ";
-                "cy"; "cy-GB";
-                "da"; "da-DK";
-                "de"; "de-AT"; "de-CH"; "de-DE"; "de-LI"; "de-LU";
-                "dsb"; "dsb-DE";
-                "dv"; "dv-MV";
-                "el"; "el-GR";
-                "en"; "en-029"; "en-AU"; "en-BZ"; "en-CA"; "en-GB"; "en-IE"; "en-IN"; "en-JM"; "en-MY"; "en-NZ"; "en-PH"; "en-SG"; "en-TT"; "en-US"; "en-ZA"; "en-ZW";
-                "es"; "es-AR"; "es-BO"; "es-CL"; "es-CO"; "es-CR"; "es-DO"; "es-EC"; "es-ES"; "es-GT"; "es-HN"; "es-MX"; "es-NI"; "es-PA"; "es-PE"; "es-PR"; "es-PY"; "es-SV"; "es-US"; "es-UY"; "es-VE";
-                "et"; "et-EE";
-                "eu"; "eu-ES";
-                "fa"; "fa-IR";
-                "fi"; "fi-FI"; "fil"; "fil-PH";
-                "fo"; "fo-FO";
-                "fr"; "fr-BE"; "fr-CA"; "fr-CH"; "fr-FR"; "fr-LU"; "fr-MC";
-                "fy"; "fy-NL";
-                "ga"; "ga-IE";
-                "gd"; "gd-GB";
-                "gl"; "gl-ES";
-                "gsw"; "gsw-FR";
-                "gu"; "gu-IN";
-                "ha"; "ha-Latn"; "ha-Latn-NG";
-                "he"; "he-IL";
-                "hi"; "hi-IN";
-                "hr"; "hr-BA"; "hr-HR";
-                "hsb"; "hsb-DE";
-                "hu"; "hu-HU";
-                "hy"; "hy-AM";
-                "id"; "id-ID";
-                "ig"; "ig-NG";
-                "ii"; "ii-CN";
-                "is"; "is-IS";
-                "it"; "it-CH"; "it-IT";
-                "iu"; "iu-Cans"; "iu-Cans-CA"; "iu-Latn"; "iu-Latn-CA";
-                "ja"; "ja-JP";
-                "ka"; "ka-GE";
-                "kk"; "kk-KZ";
-                "kl"; "kl-GL";
-                "km"; "km-KH";
-                "kn"; "kn-IN";
-                "ko"; "ko-KR"; "kok"; "kok-IN";
-                "ky"; "ky-KG";
-                "lb"; "lb-LU";
-                "lo"; "lo-LA";
-                "lt"; "lt-LT";
-                "lv"; "lv-LV";
-                "mi"; "mi-NZ";
-                "mk"; "mk-MK";
-                "ml"; "ml-IN";
-                "mn"; "mn-Cyrl"; "mn-MN"; "mn-Mong"; "mn-Mong-CN";
-                "moh"; "moh-CA";
-                "mr"; "mr-IN";
-                "ms"; "ms-BN"; "ms-MY";
-                "mt"; "mt-MT";
-                "nb"; "nb-NO";
-                "ne"; "ne-NP";
-                "nl"; "nl-BE"; "nl-NL";
-                "nn"; "nn-NO";
-                "no";
-                "nso"; "nso-ZA";
-                "oc"; "oc-FR";
-                "or"; "or-IN";
-                "pa"; "pa-IN";
-                "pl"; "pl-PL";
-                "prs"; "prs-AF";
-                "ps"; "ps-AF";
-                "pt"; "pt-BR"; "pt-PT";
-                "qut"; "qut-GT"; "quz"; "quz-BO"; "quz-EC"; "quz-PE";
-                "rm"; "rm-CH";
-                "ro"; "ro-RO";
-                "ru"; "ru-RU";
-                "rw"; "rw-RW";
-                "sa"; "sa-IN"; "sah"; "sah-RU";
-                "se"; "se-FI"; "se-NO"; "se-SE";
-                "si"; "si-LK";
-                "sk"; "sk-SK";
-                "sl"; "sl-SI";
-                "sma"; "sma-NO"; "sma-SE"; "smj"; "smj-NO"; "smj-SE"; "smn"; "smn-FI"; "sms"; "sms-FI";
-                "sq"; "sq-AL";
-                "sr"; "sr-Cyrl"; "sr-Cyrl-BA"; "sr-Cyrl-CS"; "sr-Cyrl-ME"; "sr-Cyrl-RS"; "sr-Latn"; "sr-Latn-BA"; "sr-Latn-CS"; "sr-Latn-ME"; "sr-Latn-RS";
-                "sv"; "sv-FI"; "sv-SE";
-                "sw"; "sw-KE";
-                "syr"; "syr-SY";
-                "ta"; "ta-IN";
-                "te"; "te-IN";
-                "tg"; "tg-Cyrl"; "tg-Cyrl-TJ";
-                "th"; "th-TH";
-                "tk"; "tk-TM";
-                "tn"; "tn-ZA";
-                "tr"; "tr-TR";
-                "tt"; "tt-RU";
-                "tzm"; "tzm-Latn"; "tzm-Latn-DZ";
-                "ug"; "ug-CN";
-                "uk"; "uk-UA";
-                "ur"; "ur-PK";
-                "uz"; "uz-Cyrl"; "uz-Cyrl-UZ"; "uz-Latn"; "uz-Latn-UZ";
-                "vi"; "vi-VN";
-                "wo"; "wo-SN";
-                "xh"; "xh-ZA";
-                "yo"; "yo-NG";
-                "zh"; "zh-CN"; "zh-HK"; "zh-Hans"; "zh-Hant"; "zh-MO"; "zh-SG"; "zh-TW";
-                "zu"; "zu-ZA";]
+#if PCL            
             let cultures = 
                 cultureNames |> Seq.choose (fun name -> try Some (CultureInfo name) with _ -> None)
                       |> Seq.append [ CultureInfo.InvariantCulture; 

--- a/src/FsCheck/Data.fs
+++ b/src/FsCheck/Data.fs
@@ -12,6 +12,128 @@ namespace FsCheck
 
 module internal Data =
 
+#if PCL
+
+    let cultureNames = [
+                "af"; "af-ZA";
+                "am"; "am-ET";
+                "ar"; "ar-AE"; "ar-BH"; "ar-DZ"; "ar-EG"; "ar-IQ"; "ar-JO"; "ar-KW"; "ar-LB"; "ar-LY"; "ar-MA"; "ar-OM"; "ar-QA"; "ar-SA"; "ar-SY"; "ar-TN"; "ar-YE"; "arn"; "arn-CL";
+                "as"; "as-IN";
+                "az"; "az-Cyrl"; "az-Cyrl-AZ"; "az-Latn"; "az-Latn-AZ";
+                "ba"; "ba-RU";
+                "be"; "be-BY";
+                "bg"; "bg-BG";
+                "bn"; "bn-BD"; "bn-IN";
+                "bo"; "bo-CN";
+                "br"; "br-FR";
+                "bs"; "bs-Cyrl"; "bs-Cyrl-BA"; "bs-Latn"; "bs-Latn-BA";
+                "ca"; "ca-ES";
+                "co"; "co-FR";
+                "cs"; "cs-CZ";
+                "cy"; "cy-GB";
+                "da"; "da-DK";
+                "de"; "de-AT"; "de-CH"; "de-DE"; "de-LI"; "de-LU";
+                "dsb"; "dsb-DE";
+                "dv"; "dv-MV";
+                "el"; "el-GR";
+                "en"; "en-029"; "en-AU"; "en-BZ"; "en-CA"; "en-GB"; "en-IE"; "en-IN"; "en-JM"; "en-MY"; "en-NZ"; "en-PH"; "en-SG"; "en-TT"; "en-US"; "en-ZA"; "en-ZW";
+                "es"; "es-AR"; "es-BO"; "es-CL"; "es-CO"; "es-CR"; "es-DO"; "es-EC"; "es-ES"; "es-GT"; "es-HN"; "es-MX"; "es-NI"; "es-PA"; "es-PE"; "es-PR"; "es-PY"; "es-SV"; "es-US"; "es-UY"; "es-VE";
+                "et"; "et-EE";
+                "eu"; "eu-ES";
+                "fa"; "fa-IR";
+                "fi"; "fi-FI"; "fil"; "fil-PH";
+                "fo"; "fo-FO";
+                "fr"; "fr-BE"; "fr-CA"; "fr-CH"; "fr-FR"; "fr-LU"; "fr-MC";
+                "fy"; "fy-NL";
+                "ga"; "ga-IE";
+                "gd"; "gd-GB";
+                "gl"; "gl-ES";
+                "gsw"; "gsw-FR";
+                "gu"; "gu-IN";
+                "ha"; "ha-Latn"; "ha-Latn-NG";
+                "he"; "he-IL";
+                "hi"; "hi-IN";
+                "hr"; "hr-BA"; "hr-HR";
+                "hsb"; "hsb-DE";
+                "hu"; "hu-HU";
+                "hy"; "hy-AM";
+                "id"; "id-ID";
+                "ig"; "ig-NG";
+                "ii"; "ii-CN";
+                "is"; "is-IS";
+                "it"; "it-CH"; "it-IT";
+                "iu"; "iu-Cans"; "iu-Cans-CA"; "iu-Latn"; "iu-Latn-CA";
+                "ja"; "ja-JP";
+                "ka"; "ka-GE";
+                "kk"; "kk-KZ";
+                "kl"; "kl-GL";
+                "km"; "km-KH";
+                "kn"; "kn-IN";
+                "ko"; "ko-KR"; "kok"; "kok-IN";
+                "ky"; "ky-KG";
+                "lb"; "lb-LU";
+                "lo"; "lo-LA";
+                "lt"; "lt-LT";
+                "lv"; "lv-LV";
+                "mi"; "mi-NZ";
+                "mk"; "mk-MK";
+                "ml"; "ml-IN";
+                "mn"; "mn-Cyrl"; "mn-MN"; "mn-Mong"; "mn-Mong-CN";
+                "moh"; "moh-CA";
+                "mr"; "mr-IN";
+                "ms"; "ms-BN"; "ms-MY";
+                "mt"; "mt-MT";
+                "nb"; "nb-NO";
+                "ne"; "ne-NP";
+                "nl"; "nl-BE"; "nl-NL";
+                "nn"; "nn-NO";
+                "no";
+                "nso"; "nso-ZA";
+                "oc"; "oc-FR";
+                "or"; "or-IN";
+                "pa"; "pa-IN";
+                "pl"; "pl-PL";
+                "prs"; "prs-AF";
+                "ps"; "ps-AF";
+                "pt"; "pt-BR"; "pt-PT";
+                "qut"; "qut-GT"; "quz"; "quz-BO"; "quz-EC"; "quz-PE";
+                "rm"; "rm-CH";
+                "ro"; "ro-RO";
+                "ru"; "ru-RU";
+                "rw"; "rw-RW";
+                "sa"; "sa-IN"; "sah"; "sah-RU";
+                "se"; "se-FI"; "se-NO"; "se-SE";
+                "si"; "si-LK";
+                "sk"; "sk-SK";
+                "sl"; "sl-SI";
+                "sma"; "sma-NO"; "sma-SE"; "smj"; "smj-NO"; "smj-SE"; "smn"; "smn-FI"; "sms"; "sms-FI";
+                "sq"; "sq-AL";
+                "sr"; "sr-Cyrl"; "sr-Cyrl-BA"; "sr-Cyrl-CS"; "sr-Cyrl-ME"; "sr-Cyrl-RS"; "sr-Latn"; "sr-Latn-BA"; "sr-Latn-CS"; "sr-Latn-ME"; "sr-Latn-RS";
+                "sv"; "sv-FI"; "sv-SE";
+                "sw"; "sw-KE";
+                "syr"; "syr-SY";
+                "ta"; "ta-IN";
+                "te"; "te-IN";
+                "tg"; "tg-Cyrl"; "tg-Cyrl-TJ";
+                "th"; "th-TH";
+                "tk"; "tk-TM";
+                "tn"; "tn-ZA";
+                "tr"; "tr-TR";
+                "tt"; "tt-RU";
+                "tzm"; "tzm-Latn"; "tzm-Latn-DZ";
+                "ug"; "ug-CN";
+                "uk"; "uk-UA";
+                "ur"; "ur-PK";
+                "uz"; "uz-Cyrl"; "uz-Cyrl-UZ"; "uz-Latn"; "uz-Latn-UZ";
+                "vi"; "vi-VN";
+                "wo"; "wo-SN";
+                "xh"; "xh-ZA";
+                "yo"; "yo-NG";
+                "zh"; "zh-CN"; "zh-HK"; "zh-Hans"; "zh-Hant"; "zh-MO"; "zh-SG"; "zh-TW";
+                "zu"; "zu-ZA";]
+
+#else
+
     // All valid top-level domains, taken from: http://data.iana.org/TLD/tlds-alpha-by-domain.txt
     let topLevelDomains = [| 
         "aaa";
@@ -1331,3 +1453,4 @@ module internal Data =
         "edu";
         "gov" |]
 
+#endif    


### PR DESCRIPTION
In #255, the list of top-level domains was placed in a separate `Data` module to prevent them from cluttering the `Arb` module. This PR does the same thing for the PCL-specific culture names list. It makes the `Arb` module read better IMHO.