### PR TITLE
XUnit properties - allow configuration on module level

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -89,7 +89,8 @@ Target "AssemblyInfo" (fun _ ->
           Attribute.Description package.Summary
           Attribute.Version release.AssemblyVersion
           Attribute.FileVersion release.AssemblyVersion
-        ] @ (if package.Name = "FsCheck" then [Attribute.InternalsVisibleTo("FsCheck.Test")] else []))
+        ] @ (if package.Name = "FsCheck" || package.Name = "FsCheck.Xunit"
+             then [Attribute.InternalsVisibleTo("FsCheck.Test")] else []))
     )
 )
 

--- a/docs/content/RunningTests.fsx
+++ b/docs/content/RunningTests.fsx
@@ -137,9 +137,8 @@ let ``abs(v) % k equals abs(v % k)`` v (NonZeroInt k) =
     (abs v) % k = abs(v % k)
 
 (**
-Likely on of the most useful configuration options of `PropertyAttribute` is the ability to register or override an `Arbitrary`
-instance just for that test method. You can also use the `ArbitraryAttribute` to register or override `Abritrary` instances on 
-a per class or per module basis. For example:*)
+Likely one of the most useful configuration options of `PropertyAttribute` is the ability to register or override an `Arbitrary`
+instance just for that test method. You can also use the `PropertiesAttribute` (note the plural form) to set custom configuration options per class or per module basis. For example:*)
 
 type Positive =
     static member Double() =
@@ -151,8 +150,8 @@ type Negative =
         Arb.Default.Float()
         |> Arb.mapFilter (abs >> ((-) 0.0)) (fun t -> t <= 0.0)
 
-[<Arbitrary(typeof<Negative>)>]
-module ModuleWithArbitrary =
+[<Properties( Arbitrary=[| typeof<Negative> |] )>]
+module ModuleWithProperties =
 
     [<Property>]
     let ``should use Arb instances from enclosing module``(underTest:float) =
@@ -161,6 +160,29 @@ module ModuleWithArbitrary =
     [<Property( Arbitrary=[| typeof<Positive> |] )>]
     let ``should use Arb instance on method``(underTest:float) =
         underTest >= 0.0
+
+(**
+Using `PropertiesAttribute` and `PropertyAttribute` you can set any configuration. For example in following module:
+
+* property 1 would use default config + overriden MaxTest = 10 and EndSize = 10 from `Properties` attribute
+* property 2 would use default config + overriden EndSize = 10 from `Properties` attribute and MaxTest = 500 from `Property` attribute
+* property 3 would use default config + overriden MaxTest = 10 and EndSize = 10 from `Properties` attribute and Replay = "123,456" from `Property` attribute 
+*)
+
+[<Properties(MaxTest = 10, EndSize = 10)>] 
+module Properties =
+
+    [<Property>]
+    let ``property 1`` input =
+        true
+
+    [<Property(MaxTest = 500)>]
+    let ``property 2`` input =
+        true
+
+    [<Property(Replay = "123,456")>]
+    let ``property 3`` input =
+        true
 
 (**
 ### Using FsCheck.Xunit with TestDriven.Net

--- a/src/FsCheck.Xunit/AssemblyInfo.fs
+++ b/src/FsCheck.Xunit/AssemblyInfo.fs
@@ -1,11 +1,13 @@
 ﻿namespace System
 open System.Reflection
+open System.Runtime.CompilerServices
 
 [<assembly: AssemblyTitleAttribute("FsCheck.Xunit")>]
 [<assembly: AssemblyProductAttribute("FsCheck.Xunit")>]
 [<assembly: AssemblyDescriptionAttribute("Integrates FsCheck with xUnit.NET")>]
 [<assembly: AssemblyVersionAttribute("2.5.1")>]
 [<assembly: AssemblyFileVersionAttribute("2.5.1")>]
+[<assembly: InternalsVisibleToAttribute("FsCheck.Test")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -146,8 +146,9 @@ type public PropertyAttribute() =
 
     member internal __.Config = config
 
+///Set common configuration for all properties within this class or module
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
-type public GeneralAttribute() = inherit PropertyAttribute()
+type public PropertiesAttribute() = inherit PropertyAttribute()
 
 /// The xUnit2 test runner for the PropertyAttribute that executes the test via FsCheck
 type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:TestMethodDisplay, testMethod:ITestMethod, ?testMethodArguments:obj []) =
@@ -162,7 +163,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                 |> Seq.collect (fun attr -> attr.GetNamedArgument "Arbitrary")
                 |> Seq.toArray
         let generalAttribute = 
-            this.TestMethod.TestClass.Class.GetCustomAttributes(typeof<GeneralAttribute>) 
+            this.TestMethod.TestClass.Class.GetCustomAttributes(typeof<PropertiesAttribute>) 
                 |> Seq.tryFind (fun _ -> true)
 
         let config =

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -36,37 +36,71 @@ type ArbitraryAttribute(types:Type[]) =
     new(typ:Type) = ArbitraryAttribute([|typ|])
     member __.Arbitrary = types
 
-[<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
-type public GeneralAttribute() =
-    inherit Attribute()
-    let mutable replay = Config.Default.Replay
-    member internal __.ReplayStdGen = replay //interestingly, although this member is unused, if you remove it tests will fail...?
+type internal PropertyConfig =
+    { MaxTest        : Option<int>
+      MaxFail        : Option<int>
+      Replay         : Option<Random.StdGen>
+      StartSize      : Option<int>
+      EndSize        : Option<int>
+      Verbose        : Option<bool>
+      QuietOnSuccess : Option<bool>
+      Arbitrary      : Type[] }
 
-    member __.Replay with get() = match replay with None -> String.Empty | Some (Random.StdGen (x,y)) -> sprintf "%A" (x,y)
-                     and set(v:string) =
-                        //if someone sets this, we want it to throw if it fails
-                        let split = v.Trim('(',')').Split([|","|], StringSplitOptions.RemoveEmptyEntries)
-                        let elem1 = Int32.Parse(split.[0])
-                        let elem2 = Int32.Parse(split.[1])
-                        replay <- Some <| Random.StdGen (elem1,elem2)
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module internal PropertyConfig = 
+    let orElse y = function
+        | Some x -> Some x
+        | None   -> y
+
+    let orDefault x y = defaultArg y x
+
+    let combine extra original =
+        { MaxTest        = extra.MaxTest        |> orElse original.MaxTest
+          MaxFail        = extra.MaxFail        |> orElse original.MaxFail
+          Replay         = extra.Replay         |> orElse original.Replay
+          StartSize      = extra.StartSize      |> orElse original.StartSize
+          EndSize        = extra.EndSize        |> orElse original.EndSize
+          Verbose        = extra.Verbose        |> orElse original.Verbose
+          QuietOnSuccess = extra.QuietOnSuccess |> orElse original.QuietOnSuccess
+          Arbitrary      = Array.append original.Arbitrary extra.Arbitrary }
+    
+    let toConfig (output : TestOutputHelper) propertyConfig =
+        { Config.Default with
+              Replay         = propertyConfig.Replay         |> orElse    Config.Default.Replay
+              MaxTest        = propertyConfig.MaxTest        |> orDefault Config.Default.MaxTest
+              MaxFail        = propertyConfig.MaxFail        |> orDefault Config.Default.MaxFail
+              StartSize      = propertyConfig.StartSize      |> orDefault Config.Default.StartSize
+              EndSize        = propertyConfig.EndSize        |> orDefault Config.Default.EndSize
+              QuietOnSuccess = propertyConfig.QuietOnSuccess |> orDefault Config.Default.QuietOnSuccess
+              Arbitrary      = Seq.toList propertyConfig.Arbitrary
+              Runner         = new XunitRunner()
+              Every          = 
+                  if propertyConfig.Verbose |> Option.exists id then 
+                      fun n args -> output.WriteLine (Config.Verbose.Every n args); ""
+                  else 
+                      Config.Quick.Every
+              EveryShrink    = 
+                  if propertyConfig.Verbose |> Option.exists id then 
+                      fun args -> output.WriteLine (Config.Verbose.EveryShrink args); ""
+                  else 
+                      Config.Quick.EveryShrink }
 
 ///Run this method as an FsCheck test.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 [<XunitTestCaseDiscoverer("FsCheck.Xunit.PropertyDiscoverer", "FsCheck.Xunit")>]
 type public PropertyAttribute() =
     inherit FactAttribute()
-    let mutable maxTest = Config.Default.MaxTest
-    let mutable maxFail = Config.Default.MaxFail
-    let mutable replay = Config.Default.Replay
-    let mutable startSize = Config.Default.StartSize
-    let mutable endSize = Config.Default.EndSize
-    let mutable verbose = false
-    let mutable quietOnSuccess = false
-    let mutable arbitrary = Config.Default.Arbitrary |> List.toArray
+    let mutable maxTest        = None
+    let mutable maxFail        = None
+    let mutable replay         = None
+    let mutable startSize      = None
+    let mutable endSize        = None
+    let mutable verbose        = None
+    let mutable quietOnSuccess = None
+    let mutable arbitrary      = [||]
     ///If set, the seed to use to start testing. Allows reproduction of previous runs. You can just paste
     ///the tuple from the output window, e.g. 12344,12312 or (123,123).
-    member __.Replay with get() = match replay with None -> String.Empty | Some (Random.StdGen (x,y)) -> sprintf "%A" (x,y)
-                     and set(v:string) =
+    member __.Replay with set(v:string) =
                         //if someone sets this, we want it to throw if it fails
                         let split = v.Trim('(',')').Split([|","|], StringSplitOptions.RemoveEmptyEntries)
                         let elem1 = Int32.Parse(split.[0])
@@ -74,26 +108,39 @@ type public PropertyAttribute() =
                         replay <- Some <| Random.StdGen (elem1,elem2)
     member internal __.ReplayStdGen = replay //interestingly, although this member is unused, if you remove it tests will fail...?
     ///The maximum number of tests that are run.
-    member __.MaxTest with get() = maxTest and set(v) = maxTest <- v
+    member __.MaxTest with set(v) = maxTest <- Some v
     ///The maximum number of tests where values are rejected, e.g. as the result of ==>
-    member __.MaxFail with get() = maxFail and set(v) = maxFail <- v
+    member __.MaxFail with set(v) = maxFail <- Some v
     ///The size to use for the first test.
-    member __.StartSize with get() = startSize and set(v) = startSize <- v
+    member __.StartSize with set(v) = startSize <- Some v
     ///The size to use for the last test, when all the tests are passing. The size increases linearly between Start- and EndSize.
-    member __.EndSize with get() = endSize and set(v) = endSize <- v
+    member __.EndSize with set(v) = endSize <- Some v
     ///Output all generated arguments.
-    member __.Verbose with get() = verbose and set(v) = verbose <- v
+    member __.Verbose with set(v) = verbose <- Some v
     ///The Arbitrary instances to use for this test method. The Arbitrary instances
     ///are merged in back to front order i.e. instances for the same generated type
     ///at the front of the array will override those at the back.
-    member __.Arbitrary with get() = arbitrary and set(v) = arbitrary <- v
+    member __.Arbitrary with set(v) = arbitrary <- v
     ///If set, suppresses the output from the test if the test is successful. This can be useful when running tests
     ///with TestDriven.net, because TestDriven.net pops up the Output window in Visual Studio if a test fails; thus,
     ///when conditioned to that behaviour, it's always a bit jarring to receive output from passing tests.
     ///The default is false, which means that FsCheck will also output test results on success, but if set to true,
     ///FsCheck will suppress output in the case of a passing test. This setting doesn't affect the behaviour in case of
     ///test failures.
-    member __.QuietOnSuccess with get() = quietOnSuccess and set(v) = quietOnSuccess <- v
+    member __.QuietOnSuccess with set(v) = quietOnSuccess <- Some v
+
+    member internal __.Config =
+        { MaxTest        = maxTest
+          MaxFail        = maxFail
+          Replay         = replay
+          StartSize      = startSize
+          EndSize        = endSize
+          Verbose        = verbose
+          QuietOnSuccess = quietOnSuccess
+          Arbitrary      = arbitrary }
+
+[<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
+type public GeneralAttribute() = inherit PropertyAttribute()
 
 /// The xUnit2 test runner for the PropertyAttribute that executes the test via FsCheck
 type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:TestMethodDisplay, testMethod:ITestMethod, ?testMethodArguments:obj []) =
@@ -103,40 +150,25 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
 
     member this.Init(output:TestOutputHelper) =
         let factAttribute = this.TestMethod.Method.GetCustomAttributes(typeof<PropertyAttribute>) |> Seq.head
-        let arbitrariesOnMethod = factAttribute.GetNamedArgument "Arbitrary"
         let arbitrariesOnClass =
             this.TestMethod.TestClass.Class.GetCustomAttributes(typeof<ArbitraryAttribute>)
                 |> Seq.collect (fun attr -> attr.GetNamedArgument "Arbitrary")
+                |> Seq.toArray
         let generalAttribute = 
             this.TestMethod.TestClass.Class.GetCustomAttributes(typeof<GeneralAttribute>) 
                 |> Seq.tryFind (fun _ -> true)
 
-        let arbitraries =
-            Config.Default.Arbitrary
-            |> Seq.append arbitrariesOnClass
-            |> Seq.append arbitrariesOnMethod
-            |> Seq.toList
-
-        { Config.Default with
-                Replay = 
-                    let attr = defaultArg generalAttribute factAttribute
-                    attr.GetNamedArgument("ReplayStdGen")
-                MaxTest = factAttribute.GetNamedArgument("MaxTest")
-                MaxFail = factAttribute.GetNamedArgument("MaxFail")
-                StartSize = factAttribute.GetNamedArgument("StartSize")
-                EndSize = factAttribute.GetNamedArgument("EndSize")
-                QuietOnSuccess = factAttribute.GetNamedArgument("QuietOnSuccess")
-                Every = if factAttribute.GetNamedArgument("Verbose") then 
-                            fun n args -> output.WriteLine (Config.Verbose.Every n args); ""
-                        else 
-                            Config.Quick.Every
-                EveryShrink = if factAttribute.GetNamedArgument("Verbose") then 
-                                fun args -> output.WriteLine (Config.Verbose.EveryShrink args); ""
-                                else 
-                                    Config.Quick.EveryShrink
-                Arbitrary = arbitraries
-                Runner = new XunitRunner()
-            }
+        let config =
+            match generalAttribute with
+            | Some generalAttribute ->
+                PropertyConfig.combine
+                    (factAttribute.GetNamedArgument "Config")
+                    (generalAttribute.GetNamedArgument "Config")
+            | None ->
+                factAttribute.GetNamedArgument "Config"
+        
+        { config with Arbitrary = Array.append config.Arbitrary arbitrariesOnClass }
+        |> PropertyConfig.toConfig output 
 
     override this.RunAsync(diagnosticMessageSink:IMessageSink, messageBus:IMessageBus, constructorArguments:obj [], aggregator:ExceptionAggregator, cancellationTokenSource:Threading.CancellationTokenSource) =
         let test = new XunitTest(this, this.DisplayName)

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -36,6 +36,19 @@ type ArbitraryAttribute(types:Type[]) =
     new(typ:Type) = ArbitraryAttribute([|typ|])
     member __.Arbitrary = types
 
+[<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
+type public GeneralAttribute() =
+    inherit Attribute()
+    let mutable replay = Config.Default.Replay
+
+    member __.Replay with get() = match replay with None -> String.Empty | Some (Random.StdGen (x,y)) -> sprintf "%A" (x,y)
+                     and set(v:string) =
+                        //if someone sets this, we want it to throw if it fails
+                        let split = v.Trim('(',')').Split([|","|], StringSplitOptions.RemoveEmptyEntries)
+                        let elem1 = Int32.Parse(split.[0])
+                        let elem2 = Int32.Parse(split.[1])
+                        replay <- Some <| Random.StdGen (elem1,elem2)
+
 ///Run this method as an FsCheck test.
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple = false)>]
 [<XunitTestCaseDiscoverer("FsCheck.Xunit.PropertyDiscoverer", "FsCheck.Xunit")>]

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -31,6 +31,7 @@ type XunitRunner() =
 ///Override Arbitrary instances for FsCheck tests within the attributed class
 ///or module.
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
+[<Obsolete("Please use PropertiesAttribute instead.")>]
 type ArbitraryAttribute(types:Type[]) =
     inherit Attribute()
     new(typ:Type) = ArbitraryAttribute([|typ|])

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -72,7 +72,7 @@ module internal PropertyConfig =
           EndSize        = extra.EndSize        |> orElse original.EndSize
           Verbose        = extra.Verbose        |> orElse original.Verbose
           QuietOnSuccess = extra.QuietOnSuccess |> orElse original.QuietOnSuccess
-          Arbitrary      = Array.append original.Arbitrary extra.Arbitrary }
+          Arbitrary      = Array.append extra.Arbitrary original.Arbitrary }
 
     let parseStdGen (str: string) =
         //if someone sets this, we want it to throw if it fails

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -99,6 +99,17 @@ module Runner =
         let ``should use Arb instance on method preferentially``(underTest:float) =
             underTest >= 0.0
 
+    [<Properties(Arbitrary = [| typeof<TestArbitrary2> |])>]
+    module ModuleWithProperties =
+
+        [<Property>]
+        let ``should use Arb instances from enclosing module``(underTest:float) =
+            underTest <= 0.0
+
+        [<Property( Arbitrary=[| typeof<TestArbitrary1> |] )>]
+        let ``should use Arb instance on method preferentially``(underTest:float) =
+            underTest >= 0.0
+
 module BugReproIssue195 =
 
     open FsCheck

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -90,15 +90,31 @@ module Runner =
         let extra    = { PropertyConfig.zero with Arbitrary = [| typeof<TestArbitrary2> |] }
         let combined = PropertyConfig.combine extra original
 
-        test <@ combined.Arbitrary.[0] = typeof<TestArbitrary2> @>
+        combined.Arbitrary.[0] =! typeof<TestArbitrary2>
 
-    [<Fact>]
-    let ``PropertyConfig combine should favor extra config``() =
-        let original = { PropertyConfig.zero with MaxTest = Some 1 }
-        let extra    = { PropertyConfig.zero with MaxTest = Some 2 }
+    [<Property>]
+    let ``PropertyConfig combine should favor extra config``(orignalMaxTest, extraMaxTest) =
+        let original = { PropertyConfig.zero with MaxTest = Some orignalMaxTest }
+        let extra    = { PropertyConfig.zero with MaxTest = Some extraMaxTest }
         let combined = PropertyConfig.combine extra original
 
-        test <@ combined.MaxTest = Some 2 @>
+        combined.MaxTest =! Some extraMaxTest
+
+    [<Property>]
+    let ``PropertyConfig toConfig should favor specified setting``(maxTest) =
+        let propertyConfig = { PropertyConfig.zero with MaxTest = Some maxTest }
+        let testOutputHelper = new Sdk.TestOutputHelper()
+        let config = PropertyConfig.toConfig testOutputHelper propertyConfig
+
+        config.MaxTest =! maxTest
+
+    [<Fact>]
+    let ``PropertyConfig toConfig should use defaults as a fallback``() =
+        let propertyConfig = PropertyConfig.zero
+        let testOutputHelper = new Sdk.TestOutputHelper()
+        let config = PropertyConfig.toConfig testOutputHelper propertyConfig
+
+        config.MaxTest =! Config.Default.MaxTest
 
     type TypeToInstantiate() =
         [<Property>]

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -100,7 +100,7 @@ module Runner =
             underTest >= 0.0
 
     [<Properties(Arbitrary = [| typeof<TestArbitrary2> |])>]
-    module ModuleWithProperties =
+    module ModuleWithPropertiesArb =
 
         [<Property>]
         let ``should use Arb instances from enclosing module``(underTest:float) =
@@ -109,6 +109,19 @@ module Runner =
         [<Property( Arbitrary=[| typeof<TestArbitrary1> |] )>]
         let ``should use Arb instance on method preferentially``(underTest:float) =
             underTest >= 0.0
+
+    [<Properties( MaxTest = 1, StartSize = 100, EndSize = 100, Replay = "01234,56789")>]
+    module ModuleWithPropertiesConfig =
+
+        [<Property>]
+        let ``should use configuration from enclosing module``(x:int) =
+            // checking if the generated value is always the same (-59) from "01234,56789" Replay
+            x =! -59
+
+        [<Property( Replay = "12345,67890")>]
+        let ``should use configuration on method preferentially``(x:int) =
+            // checking if the generated value is always the same (18) from "12345,67890" Replay
+            x =! 18
 
 module BugReproIssue195 =
 

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -84,6 +84,22 @@ module Runner =
         //this test
         ()
 
+    [<Fact>]
+    let ``PropertyConfig combine should prepend extra Arbitrary``() =
+        let original = { PropertyConfig.zero with Arbitrary = [| typeof<TestArbitrary1> |] }
+        let extra    = { PropertyConfig.zero with Arbitrary = [| typeof<TestArbitrary2> |] }
+        let combined = PropertyConfig.combine extra original
+
+        test <@ combined.Arbitrary.[0] = typeof<TestArbitrary2> @>
+
+    [<Fact>]
+    let ``PropertyConfig combine should favor extra config``() =
+        let original = { PropertyConfig.zero with MaxTest = Some 1 }
+        let extra    = { PropertyConfig.zero with MaxTest = Some 2 }
+        let combined = PropertyConfig.combine extra original
+
+        test <@ combined.MaxTest = Some 2 @>
+
     type TypeToInstantiate() =
         [<Property>]
         member __.``Should run a property on an instance``(_:int) = ()


### PR DESCRIPTION
**Marking with WIP prefix** to get early feedback

This is what I came up with regarding #282.
Unfortunately the change turned out to be quite big.

The basic idea is to allow configuring properties on class/module level, and override the config on property level.
For that purpose I've created internal `PropertyConfig` type which represents values of `PropertyAttribute`.
In addition to that, I've made a derived class from `PropertyAttribute` called `GeneralAttribute` (name should probably be changed).
The subclass relation is there to remove code duplication and maintain .net Attribute requirements (public automatic properties)

One of drawbacks is that with these changes, there would be 2 possible ways to add `Arbitrary` types on class/module level: with `ArbitraryAttribute` and `GeneralAttribute`

Any comments welcome - if you decide that the change is too big / breaking and should not be merged, I'll be fine with that as well.