### PR TITLE
when you have a module of property based tests, and no zero param exa…

### DIFF
--- a/src/FsCheck/TypeClass.fs
+++ b/src/FsCheck/TypeClass.fs
@@ -73,7 +73,7 @@ module TypeClass =
             | _ -> acc
         let addMethods (t:Type) =
             t.GetRuntimeMethods()
-            |> Seq.where(fun meth -> meth.IsStatic && (meth.IsPublic || not onlyPublic) && meth.GetParameters().Length = 0)
+            |> Seq.where(fun meth -> meth.IsStatic && (meth.IsPublic || not onlyPublic))
             |> Seq.fold addMethod []
         let instances = addMethods instancesType
         if instances.Length = 0 then 


### PR DESCRIPTION
fix for when you've only got property-based tests in a module, and when Arb.registerByType gets called (when manually invoked via FSI).  It looks to me that the = 0 params guard is no longer needed.  Please confirm if I am reading this correctly.