### PR TITLE
Handled char-based flags enums.

### DIFF
--- a/src/FsCheck/ReflectArbitrary.fs
+++ b/src/FsCheck/ReflectArbitrary.fs
@@ -45,6 +45,7 @@ module internal ReflectArbitrary =
            elif elementType = typeof<int>    then listOf elems |> map (orElems<int>    t)
            elif elementType = typeof<uint64> then listOf elems |> map (orElems<uint64> t)
            elif elementType = typeof<int64>  then listOf elems |> map (orElems<int64>  t)
+           elif elementType = typeof<char>   then elems // Binary 'or' not defined for char enums
            else invalidArg "t" (sprintf "Unexpected underlying enum type: %O" elementType)
        else 
            elems

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -402,6 +402,13 @@ module Arbitrary =
     let ``Can create 64-bit integer flags enumeration`` (value : LongFlags) =
         List.exists (fun e -> e = int64 value) [0L..7L]
 
+    [<Flags>]
+    type CharFlags = A = 'A' | B = 'B' | C = 'C'
+
+    [<Property>]
+    let ``Can create char flags enumeration`` (value : CharFlags) =
+        List.exists ((=) value) [CharFlags.A; CharFlags.B; CharFlags.C]
+
     [<Fact>]
     let ``FsList shrunk is at minimum n-1``() =
         let prop (l:int list) = 


### PR DESCRIPTION
As far as I can tell, char-based flags enums don't make much sense, since
they don't seem to support binary 'or' or 'and'. (If there's a way to 'or'
two char-based flags together, I haven't found out how to do it.) As the
added test demonstrates, however, it's possible to define and compile a
char-based flags enum, so FsCheck ought to explicitly handle such a type.