### PR TITLE
Corrected an error with conditional compilation

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -984,16 +984,14 @@ module Arb =
                 |> Seq.map IPAddress
         
             fromGenShrink (generator, shrinker)
-
-#if PCL
-#else
+#endif
 
         static member HostName() =
             let isValidSubdomain (subDomain: string) = String.IsNullOrWhiteSpace subDomain |> not && subDomain.Length <= 63 && subDomain.StartsWith("-") |> not && subDomain.EndsWith("-") |> not
             let isValidHost (host: string) = String.IsNullOrWhiteSpace host |> not && host.Length <= 255 && host.StartsWith(".") |> not && host.Split('.') |> Array.forall isValidSubdomain
             let subdomain = 
                 gen {
-                    let subdomainCharacters = "abcdefghijklmnopqrstuvwxyz0123456789-"
+                    let subdomainCharacters = "abcdefghijklmnopqrstuvwxyz0123456789-".ToCharArray()
                     let! subdomainLength = Gen.choose (1, 63)
                     return! 
                         Gen.elements subdomainCharacters 
@@ -1028,8 +1026,8 @@ module Arb =
 
             fromGenShrink (host, shrinkHost)
 
-#endif
-
+#if PCL
+#else
         static member MailAddress() =
             let isValidUser (user: string) = 
                 String.IsNullOrWhiteSpace user |> not &&

--- a/src/FsCheck/Data.fs
+++ b/src/FsCheck/Data.fs
@@ -131,8 +131,8 @@ module internal Data =
                 "yo"; "yo-NG";
                 "zh"; "zh-CN"; "zh-HK"; "zh-Hans"; "zh-Hant"; "zh-MO"; "zh-SG"; "zh-TW";
                 "zu"; "zu-ZA";]
-
 #else
+#endif
 
     // All valid top-level domains, taken from: http://data.iana.org/TLD/tlds-alpha-by-domain.txt
     let topLevelDomains = [| 
@@ -1452,5 +1452,3 @@ module internal Data =
         "info";
         "edu";
         "gov" |]
-
-#endif    


### PR DESCRIPTION
This is very embarrassing, but as far as I can tell, I made an error in my last commit. The intent was to
make HostName available on both the full framework and PCL, but I think I got it wrong. I hope this commit fixes it.

**Given that my previous pull request demonstrates that I'm having trouble with conditional compilation, an extra-critical code review would be in order here!**

Sorry about the mess :flushed: 

The call to ToCharArray() is necessary because, apparently, System.String doesn't implement `char seq` on all portable platforms... At least, without it, compilation fails on PCL.