### PR TITLE
Fixed regression in VB.NET support

### DIFF
--- a/src/FsCheck/Common.fs
+++ b/src/FsCheck/Common.fs
@@ -70,3 +70,11 @@ module internal Common =
         // (making sure that the enumerator gets disposed)
         seq { use en = s.GetEnumerator()
             yield! loop en }
+
+
+    //  !!! NOTE !!!
+    //  ----------------
+    //  This attribute is required to properly expose extension methods to VB consumers. 
+    //  It only needs to appear _once_ in the entire assembly -- but it is needed.
+    [<assembly: System.Runtime.CompilerServices.Extension>]
+    do ()


### PR DESCRIPTION
This addresses a regression to the fix made in #134. The regression seems to be caused by FAKE stomping on the `AssemblyInfo.fs` file (where the code lifed previously). So, as a fix, the code (a 2 lines of it), is moved to a different file (one that doesn't get rewritten as part of the build process). Additionally, the commit includes a code comment, since the code looks a bit out-of-place in it's new location.