### PR TITLE
Overrode HostName.ToString()

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -140,7 +140,8 @@ type IPv4Address = IPv4Address of IPAddress
 type IPv6Address = IPv6Address of IPAddress
 #endif
 
-type HostName = HostName of string
+type HostName = HostName of string with
+    override x.ToString () = match x with HostName s -> s
 
 [<AutoOpen>]
 module ArbPatterns =

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -499,6 +499,10 @@ module Arbitrary =
     let ``HostName is useful in an Uri`` (HostName host) =
         Uri.TryCreate (sprintf "http://%s" host, UriKind.Absolute) |> fst
 
+    [<Property>]
+    let ``HostName correctly turns to string`` (HostName expected as value) =
+        expected = string value
+
     [<Fact>]
     let MailAddress () =
         generate<MailAddress> |> sample 10 |> ignore


### PR DESCRIPTION
Since HostName is only a wrapper over string anyway, it'd be reasonable to
override ToString() to return the string in question.