### PR TITLE
Zip and unzip

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -331,9 +331,20 @@ module Gen =
     //[category: Creating generators from generators]
     let zip f g = map2 (fun x y -> x, y) f g
 
+    ///Combine three generators into a generator of 3-tuples.
+    //[category: Creating generators from generators]
+    let zip3 f g h = map3 (fun x y z -> x, y, z) f g h
+
     ///Split a generator of pairs into a pair of generators.
     //[category: Creating generators from generators]
     let unzip g = map fst g, map snd g
+
+    ///Split a generator of 3-tuples into a 3-tuple of generators.
+    //[category: Creating generators from generators]
+    let unzip3 g =
+        map (fun (x, _, _) -> x) g,
+        map (fun (_, y, _) -> y) g,
+        map (fun (_, _, z) -> z) g
 
     ///Sequence the given seq of generators into a generator of a list.
     //[category: Creating generators from generators]

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -327,6 +327,14 @@ module Gen =
                                             let! g' = g
                                             return f a' b' c' d' e' g'}
 
+    ///Combine two generators into a generator of pairs.
+    //[category: Creating generators from generators]
+    let zip f g = map2 (fun x y -> x, y) f g
+
+    ///Split a generator of pairs into a pair of generators.
+    //[category: Creating generators from generators]
+    let unzip g = map fst g, map snd g
+
     ///Sequence the given seq of generators into a generator of a list.
     //[category: Creating generators from generators]
     [<CompiledName("SequenceToList"); EditorBrowsable(EditorBrowsableState.Never)>]

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -114,9 +114,20 @@ module Gen =
         |> ((=) (a, b))
 
     [<Property>]
+    let Zip3 (a : int) (b : char) (c : bool) =
+        Gen.zip3 (Gen.constant a) (Gen.constant b) (Gen.constant c)
+        |> sample1
+        |> ((=) (a, b, c))
+
+    [<Property>]
     let Unzip (a : char) (b : int) =
         let f, g = Gen.constant (a, b) |> Gen.unzip
         (sample1 f, sample1 g) = (a, b)
+
+    [<Property>]
+    let Unzip3 (a : char) (b : int) (c : bool) =
+        let f, g, h = Gen.constant (a, b, c) |> Gen.unzip3
+        (sample1 f, sample1 g, sample1 h) = (a, b, c)
 
     [<Property>]
     let Two (v:int) =

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -106,7 +106,18 @@ module Gen =
         Gen.map6 f (Gen.constant a) (Gen.constant b) (Gen.constant c) (Gen.constant d) (Gen.constant e) (Gen.constant g)
         |> sample1
         |> ((=) (f a b c d e g))
-    
+
+    [<Property>]
+    let Zip (a : int) (b : char) =
+        Gen.zip (Gen.constant a) (Gen.constant b)
+        |> sample1
+        |> ((=) (a, b))
+
+    [<Property>]
+    let Unzip (a : char) (b : int) =
+        let f, g = Gen.constant (a, b) |> Gen.unzip
+        (sample1 f, sample1 g) = (a, b)
+
     [<Property>]
     let Two (v:int) =
         Gen.two (Gen.constant v)
@@ -222,7 +233,6 @@ module Gen =
             (Array2D.length1 arr <= rows) 
             && (Array2D.length2 arr <= cols) 
             && (seq { for elem in arr do yield elem :?> int} |> Seq.forall ((=) v))
-
 
     type MaybeNull =
         {


### PR DESCRIPTION
I was writing some code the other day, and needed `Gen.zip`. It was easy enough to define in my local code base, but I thought it might as well belong to FsCheck itself.

Since `List` defines `zip`, `zip3`, `unzip`, and `unzip3`, I've added equivalent functions in this pull request, but no more - that is, not `zip4`, `zip5`, and so on...