### PR TITLE
Gen.uri

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -1168,15 +1168,23 @@ module Arb =
         static member UriHost() =
             let genUriHostName =
                 Default.HostName().Generator |> Gen.map UriHostName
+            let shrinkUriHostName = Default.HostName().Shrinker
 #if PCL
             let genUriHost = genUriHostName
+            let shrinkUriHost (UriHostName hn) =
+                shrinkUriHostName hn |> Seq.map UriHostName
 #else
             let genIPAddressHostName =
                 Default.IPAddress().Generator |> Gen.map UriIPHost
+            let shrinkIPAddressHost = Default.IPAddress().Shrinker
+
             let genUriHost =
                 Gen.oneof [genUriHostName; genIPAddressHostName]
+            let shrinkUriHost = function
+                | UriHostName hn -> shrinkUriHostName hn |> Seq.map UriHostName
+                | UriIPHost ip -> shrinkIPAddressHost ip |> Seq.map UriIPHost
 #endif
-            fromGen genUriHost
+            fromGenShrink (genUriHost, shrinkUriHost)
 
         ///Arbitray instance for BigInteger.
         static member BigInt() =

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -142,8 +142,10 @@ type IPv6Address = IPv6Address of IPAddress
 
 type HostName = HostName of string with
     override x.ToString () = match x with HostName s -> s
-type UriScheme = UriScheme of string
-type UriHost = UriHost of string
+type UriScheme = UriScheme of string with
+    override x.ToString () = match x with UriScheme s -> s
+type UriHost = UriHost of string with
+    override x.ToString () = match x with UriHost s -> s
 
 [<AutoOpen>]
 module ArbPatterns =

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -162,6 +162,9 @@ with
             else string ip
 #endif
 
+type UriPathSegment = UriPathSegment of string with
+    override x.ToString () = match x with UriPathSegment s -> s
+
 [<AutoOpen>]
 module ArbPatterns =
     let (|Fun|) (f:Function<'a,'b>) = f.Value
@@ -1185,6 +1188,14 @@ module Arb =
                 | UriIPHost ip -> shrinkIPAddressHost ip |> Seq.map UriIPHost
 #endif
             fromGenShrink (genUriHost, shrinkUriHost)
+
+        static member UriPathSegment() =
+            let g =
+                ['a'..'z'] @ ['A'..'Z'] @ ['0'..'9'] @ ['-'; '.'; '_'; '~']
+                |> Gen.elements
+                |> Gen.nonEmptyListOf
+                |> Gen.map (List.toArray >> String >> UriPathSegment)
+            fromGen g
 
         ///Arbitray instance for BigInteger.
         static member BigInt() =

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -518,8 +518,16 @@ module Arbitrary =
         |> fst
 
     [<Property>]
+    let ``UriScheme correctly turns to string`` (UriScheme expected as value) =
+        expected = string value
+
+    [<Property>]
     let ``UriHost can be used in a URI`` (UriHost host) =
         Uri.TryCreate (sprintf "http://%s" host, UriKind.Absolute) |> fst
+
+    [<Property>]
+    let ``UriHost correctly turns to string`` (UriHost expected as value) =
+        expected = string value
 
     [<Property>]
     let Bigint (value:bigint) =

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -518,6 +518,10 @@ module Arbitrary =
         |> fst
 
     [<Property>]
+    let ``UriHost can be used in a URI`` (UriHost host) =
+        Uri.TryCreate (sprintf "http://%s" host, UriKind.Absolute) |> fst
+
+    [<Property>]
     let Bigint (value:bigint) =
         generate<bigint> |> sample 10 |> Seq.forall (fun _ -> true)
         && (shrink<bigint> value |> Seq.forall (fun shrunkv -> shrunkv <= abs value))

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -526,6 +526,12 @@ module Arbitrary =
         Uri.TryCreate (sprintf "http://%O" host, UriKind.Absolute) |> fst
 
     [<Property>]
+    let ``UriPathSegments can be used in a URI`` (segments : UriPathSegment list) =
+        let ss = System.String.Join ("/", segments)
+        Uri.TryCreate (sprintf "http://example.com/%s" ss, UriKind.Absolute)
+        |> fst
+
+    [<Property>]
     let Bigint (value:bigint) =
         generate<bigint> |> sample 10 |> Seq.forall (fun _ -> true)
         && (shrink<bigint> value |> Seq.forall (fun shrunkv -> shrunkv <= abs value))

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -522,12 +522,8 @@ module Arbitrary =
         expected = string value
 
     [<Property>]
-    let ``UriHost can be used in a URI`` (UriHost host) =
-        Uri.TryCreate (sprintf "http://%s" host, UriKind.Absolute) |> fst
-
-    [<Property>]
-    let ``UriHost correctly turns to string`` (UriHost expected as value) =
-        expected = string value
+    let ``UriHost can be used in a URI`` (host : UriHost) =
+        Uri.TryCreate (sprintf "http://%O" host, UriKind.Absolute) |> fst
 
     [<Property>]
     let Bigint (value:bigint) =

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -513,6 +513,11 @@ module Arbitrary =
         |> Seq.forall (fun shrunkv -> shrunkv.ToString().Length < value.ToString().Length || shrunkv.Host <> value.Host)
 
     [<Property>]
+    let ``UriScheme can be used in a URI`` (UriScheme scheme) =
+        Uri.TryCreate (sprintf "%s://example.com" scheme, UriKind.Absolute)
+        |> fst
+
+    [<Property>]
     let Bigint (value:bigint) =
         generate<bigint> |> sample 10 |> Seq.forall (fun _ -> true)
         && (shrink<bigint> value |> Seq.forall (fun shrunkv -> shrunkv <= abs value))


### PR DESCRIPTION
_This pull request is mostly a request for comments, and shouldn't be seen as an entirely complete body of work._

The aim is to provide building blocks for creating various forms of `Uri` values. This is done though various 'role' types that each have their own generators and shrinkers. This pull request introduces the following Arbitraties:

- UriScheme
- UriHost
- UriPathSegment (no shrinker yet)

Using these building blocks, it's possible to create truly arbitrary `Uri` values:

```
> (sprintf "%O://%O/%s") <!> Arb.generate<UriScheme> <*> Arb.generate<UriHost> <*> (Arb.generate<UriPathSegment> |> Gen.map string |> Gen.listOf |> Gen.map (String.concat "/")) |> Gen.sample 10 10;;
val it : string list =
  ["Ez://[834f:1436:ac78:3d5f:d5a1:c388:fe50:692e]/zr-k";
   "RElM04://[e7ac:ce44:10d5:f76d:39fe:2096:b884:79e8]/h~SsGg/6YD/rj2CQIi1/c8N1B/Bt_M0Sx.lZ";
   "nntp://[4466:32a8:6d8f:5d1:96b8:2efa:bfe1:57a9]/pDvaO2Uz~n/OogZ~";
   "net.tcp://rmfd4yhaya2zdbimgmdhb39c4y48ztx3uosyptntkoi-fjd5ae60.jo/.L/W-2Hhv91G/hVNs/6/r5XCQq/cqi";
   "https://v4iy-2m0bv1smqhnhlcicg8dhb3-k0717a2w26xrv1s.versicherung/V/IW";
   "net.tcp://254.246.113.219/"; "net.tcp://bugatti/mrWwo7/SQ4mvao/dAmFyU";
   "mailto://[1ec1:9c47:ac39:c387:1b37:3842:6cbf:53e9]/YDdrjXCQI/JoCu8i/8/TyMEeX.L/eXx/3IWOo7h~N1/o7HzN/~S/ydRJXCc";
   "news://31.174.120.145/9uu7-xKw/my7h/_ThTNxHH0/LC/0F";
   "net.pipe://2w0rx1vm-eo.aeg/Mml1.g/e_0B_Pbt/4NJjbp3IA/F/fo-UWNsG"]
```

, or, if you want only 'web' URLs:

```
> sprintf "%O://%O/%s" <!> (Gen.elements ["http"; "https"]) <*> Arb.generate<UriHost> <*> (Arb.generate<UriPathSegment> |> Gen.map string |> Gen.listOf |> Gen.map (String.concat "/")) |> Gen.sample 10 10;;
val it : string list =
  ["https://76.164.217.72/2/nfYyME"; "https://ntkoc-iu9iqxrv1.xperia/";
   "http://7udja59e6.qjkh64sph3zmee5i1he.business/9RH61/JZBr-VoQ/RS1GUuI5/80Af/R7LlfO/m0XxLldW/V.q9Jw0MJ/3d9A/9W_Su59jBS/OZ";
   "https://marriott/Vldnp/dvWAi/n/Ew-P3VvJ"; "https://gs/JqMssh6H5";
   "https://azure/_M0/SQ10hRIWw/Ie0s/-dsHvo/ft7ZESs";
   "http://[bf8b:1c6:e8b4:2aef:1187:5318:3ab0:7c9e]/YnnNj_w/OEN";
   "http://gd/PLlzr5KY";
   "https://[5e0c:5d6c:563b:9507:2343:bc00:8b90:47cc]/M66x.3IWw/YT29_L2/LP9CDMrFf/HWB74A/OokcQ43u/gku~LV3/LLVW5WBPp";
   "https://ug/t3XhlQaomK/VKhw0yp80"]
```

Actually, these examples cheat a bit, because they only generate strings, but one can easily generate `Uri` values from the above generators by using `Gen.map Uri` or similar techniques.

This PR doesn't include support for ports, query strings, authentication data, or fragments, because I first wanted to ask whether this is even something that's interesting to include in FsCheck.

If so, it's also my intent to introduce a built-in `Uri` Arbitrary that combines all of the above Arbitraties, as well as a built-in `WebUrl` Arbitrary that generates only HTTP-based URLs (for use with testing of e.g. RESTful services).