### PR TITLE
Add Cast() to enable type annotations in LINQ expressions

### DIFF
--- a/examples/FsCheck.CSharpExamples/Program.cs
+++ b/examples/FsCheck.CSharpExamples/Program.cs
@@ -162,7 +162,7 @@ namespace FsCheck.CSharpExamples
 
             //generators support select, selectmany and where
             var gen = from x in Arb.Generate<int>()
-                      from y in Gen.Choose(5, 10)
+                      from int y in Gen.Choose(5, 10)
                       where x > 5
                       select new { Fst = x, Snd = y };
 

--- a/src/FsCheck/GenExtensions.fs
+++ b/src/FsCheck/GenExtensions.fs
@@ -30,6 +30,10 @@ type GenExtensions =
     static member Sample(generator, size, numberOfSamples) =
         sample size numberOfSamples generator
 
+    /// Allows type annotations in LINQ expressions
+    [<System.Runtime.CompilerServices.Extension>]
+    static member Cast(g:Gen<_>) = g
+
     ///Map the given function to the value in the generator, yielding a new generator of the result type.
     [<System.Runtime.CompilerServices.Extension>]
     static member Select(g:Gen<_>, selector : Func<_,_>) = g.Map(fun a -> selector.Invoke(a))


### PR DESCRIPTION
Too bad F# doesn't allow subtyping constraints between type parameters.