### PR TITLE
[WIP] Parallel generating and testing for #83

### DIFF
--- a/docs/content/Properties.fsx
+++ b/docs/content/Properties.fsx
@@ -144,7 +144,7 @@ For example,*)
 let timesOut (a:int) = 
     lazy
         if a>10 then
-            do System.Threading.Thread.Sleep(3000)
+            do Threading.Thread.Sleep(3000)
             true
         else 
             true

--- a/docs/content/ja/Properties.fsx
+++ b/docs/content/ja/Properties.fsx
@@ -132,7 +132,7 @@ Check.Quick expectDivideByZero
 let timesOut (a:int) = 
     lazy
         if a>10 then
-            do System.Threading.Thread.Sleep(3000)
+            do Threading.Thread.Sleep(3000)
             true
         else 
             true

--- a/docs/csharp/Program.cs
+++ b/docs/csharp/Program.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CSharp.DocSnippets
+﻿namespace CSharp.DocSnippets
 {
     class Program
     {

--- a/docs/csharp/Properties.cs
+++ b/docs/csharp/Properties.cs
@@ -3,8 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CSharp.DocSnippets
 {

--- a/docs/csharp/QuickStart.cs
+++ b/docs/csharp/QuickStart.cs
@@ -1,10 +1,7 @@
 ﻿using FsCheck;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using global::Xunit;
 
 namespace CSharp

--- a/docs/csharp/StatefulTesting.cs
+++ b/docs/csharp/StatefulTesting.cs
@@ -1,9 +1,4 @@
 ﻿using FsCheck;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CSharp.DocSnippets {
 

--- a/docs/csharp/TestData.cs
+++ b/docs/csharp/TestData.cs
@@ -1,9 +1,5 @@
 ﻿using FsCheck;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CSharp.DocSnippets {
 

--- a/examples/FsCheck.CSharpExamples/Program.cs
+++ b/examples/FsCheck.CSharpExamples/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using FsCheck;
 
 namespace FsCheck.CSharpExamples
@@ -44,11 +45,15 @@ namespace FsCheck.CSharpExamples
                 throw new NotImplementedException();
             }
         }
-
+        
         static void Main(string[] args)
         {
+
+            Prop.ForAll<int>((i => Task.FromResult(i < 1000)))
+                .QuickCheck("Task");
+
             //A simple example
-            
+
             Prop.ForAll<double[]>(xs => xs.Reverse().Reverse().SequenceEqual(xs, new Eq()))
                 .QuickCheck("RevRev");
 

--- a/examples/FsCheck.Examples/Examples.fs
+++ b/examples/FsCheck.Examples/Examples.fs
@@ -196,6 +196,20 @@ Check.Quick (withNonEmptyString blah)
 let prop_Exc = forAll (Arb.fromGenShrink(Gen.resize 100 Arb.generate,Arb.shrink)) (fun (s:string) -> failwith "error")
 Check.Quick("prop_Exc",prop_Exc)
 
+//-----------------async--------
+let asyncWork (i :int) =
+    async {
+        let s = Async.Sleep i   
+        let c = Async.Sleep 1500
+        let t = 
+            [s; c]
+            |> Seq.map Async.StartAsTask
+            |> System.Threading.Tasks.Task.WhenAny
+        let! x = Async.AwaitTask t
+        return true
+    }
+let config = { Config.QuickThrowOnFailure with ParallelRunConfig = Some { MaxDegreeOfParallelism = 1 } }
+Check.One (config, asyncWork)  
 
 //-----------------test reflective shrinking--------
 type RecordStuff<'a> = { Yes:bool; Name:'a; NogIets:list<int*char> }

--- a/examples/FsCheck.Examples/Examples.fs
+++ b/examples/FsCheck.Examples/Examples.fs
@@ -27,6 +27,13 @@ Arb.register<Generators>() |> ignore
 //            override x.Arbitrary = arbitrary |> fmapGen int64 }
 //overwriteGenerators<NoInstancesFails>()
 
+
+let prop_lameTask (x:int) =
+    if x=0 then false else true
+    |> Threading.Tasks.Task.FromResult
+Check.Quick prop_lameTask
+
+
 type TestEnum =
     | First = 0
     | Second = 1

--- a/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
+++ b/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
@@ -10,10 +10,18 @@ type NUnitTest() =
     [<Test>]
     member __.NormalTest() =
         ignore true
-
+        
     [<Property>]
     member __.RevUnit (x:char) =
         List.rev [x] = [x]
+
+    // Parallelism for PropertyAttribute not implemented for Nunit yet
+    // [<Property(Parallelism = 8)>]
+//    member __.Async (i:int) =
+//        async { 
+//            do! Async.Sleep 1500
+//            return true
+//        }
   
     [<Property>]
     member __.RevApp (x:string) xs =

--- a/examples/FsCheck.XUnit.CSharpExamples/ReverseFixture.cs
+++ b/examples/FsCheck.XUnit.CSharpExamples/ReverseFixture.cs
@@ -1,15 +1,29 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using FsCheck.Xunit;
 
 namespace FsCheck.XUnit.CSharpExamples
 {
     public class ReverseFixture
     {
+        [Property(QuietOnSuccess = true, EndSize = 10000)]
+        public Task<bool> Task(int i)
+        {
+            return System.Threading.Tasks.Task.FromResult(i < 2000);
+        }
+
+        [Property(QuietOnSuccess = true, EndSize = 1000)]
+        public async Task<bool> TaskDelay(int i)
+        {
+            await System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(4)).ConfigureAwait(false);
+            return false;
+        }
+
         [Property(QuietOnSuccess = true)]
         public bool Bcl(int[] xs)
         {
-          return xs.Reverse().Reverse().SequenceEqual(xs);
+            return xs.Reverse().Reverse().SequenceEqual(xs);
         }
 
         [Property(QuietOnSuccess = true)]

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,4 +13,4 @@ nuget xunit.runner.console
 nuget xunit.runner.visualstudio version_in_path: true
 nuget FSharp.Formatting
 nuget Expecto
-nuget System.Threading
+nuget System.Threading.Thread

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -12,3 +12,5 @@ nuget xunit
 nuget xunit.runner.console
 nuget xunit.runner.visualstudio version_in_path: true
 nuget FSharp.Formatting
+nuget Expecto
+nuget System.Threading

--- a/src/FsCheck.NUnit/FsCheck.NUnit.fsproj
+++ b/src/FsCheck.NUnit/FsCheck.NUnit.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -121,6 +121,789 @@
         <Reference Include="nunit.framework">
           <HintPath>..\..\packages\NUnit\lib\net45\nunit.framework.dll</HintPath>
           <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Collections">
+          <HintPath>..\..\packages\System.Collections\ref\netstandard1.3\System.Collections.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Collections.Concurrent">
+          <HintPath>..\..\packages\System.Collections.Concurrent.4.3\lib\netstandard1.3\System.Collections.Concurrent.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Collections.Concurrent">
+          <HintPath>..\..\packages\System.Collections.Concurrent.4.3\ref\netstandard1.3\System.Collections.Concurrent.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Console">
+          <HintPath>..\..\packages\System.Console\ref\netstandard1.3\System.Console.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Debug">
+          <HintPath>..\..\packages\System.Diagnostics.Debug\ref\netstandard1.3\System.Diagnostics.Debug.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.DiagnosticSource">
+          <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource\lib\netstandard1.3\System.Diagnostics.DiagnosticSource.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Tools">
+          <HintPath>..\..\packages\System.Diagnostics.Tools\ref\netstandard1.0\System.Diagnostics.Tools.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Tracing">
+          <HintPath>..\..\packages\System.Diagnostics.Tracing.4.3\ref\netstandard1.5\System.Diagnostics.Tracing.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Globalization">
+          <HintPath>..\..\packages\System.Globalization\ref\netstandard1.3\System.Globalization.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Globalization.Calendars">
+          <HintPath>..\..\packages\System.Globalization.Calendars.4.3\ref\netstandard1.3\System.Globalization.Calendars.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Globalization.Extensions">
+          <HintPath>..\..\packages\System.Globalization.Extensions\ref\netstandard1.3\System.Globalization.Extensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\netstandard1.5\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem">
+          <HintPath>..\..\packages\System.IO.FileSystem.4.3\ref\netstandard1.3\System.IO.FileSystem.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem.Primitives">
+          <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3\lib\netstandard1.3\System.IO.FileSystem.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem.Primitives">
+          <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3\ref\netstandard1.3\System.IO.FileSystem.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>..\..\packages\System.Linq\lib\netstandard1.6\System.Linq.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>..\..\packages\System.Linq\ref\netstandard1.6\System.Linq.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>..\..\packages\System.Linq.Expressions\lib\netstandard1.6\System.Linq.Expressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>..\..\packages\System.Linq.Expressions\ref\netstandard1.6\System.Linq.Expressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Linq.Queryable">
+          <HintPath>..\..\packages\System.Linq.Queryable\ref\netstandard1.0\System.Linq.Queryable.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Linq.Queryable">
+          <HintPath>..\..\packages\System.Linq.Queryable\lib\netstandard1.3\System.Linq.Queryable.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.Mac'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoTouch'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <HintPath>..\..\packages\System.Net.Http.4.3.1\ref\netstandard1.3\System.Net.Http.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.tvOS'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.watchOS'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.Primitives">
+          <HintPath>..\..\packages\System.Net.Primitives.4.3\ref\netstandard1.3\System.Net.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.Requests">
+          <HintPath>..\..\packages\System.Net.Requests\ref\netstandard1.3\System.Net.Requests.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Net.WebHeaderCollection">
+          <HintPath>..\..\packages\System.Net.WebHeaderCollection\lib\netstandard1.3\System.Net.WebHeaderCollection.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.WebHeaderCollection">
+          <HintPath>..\..\packages\System.Net.WebHeaderCollection\ref\netstandard1.3\System.Net.WebHeaderCollection.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.ObjectModel">
+          <HintPath>..\..\packages\System.ObjectModel.4.3\lib\netstandard1.3\System.ObjectModel.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.ObjectModel">
+          <HintPath>..\..\packages\System.ObjectModel.4.3\ref\netstandard1.3\System.ObjectModel.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>..\..\packages\System.Reflection\ref\netstandard1.5\System.Reflection.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit">
+          <HintPath>..\..\packages\System.Reflection.Emit\ref\netstandard1.1\System.Reflection.Emit.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit">
+          <HintPath>..\..\packages\System.Reflection.Emit\lib\netstandard1.3\System.Reflection.Emit.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.ILGeneration">
+          <HintPath>..\..\packages\System.Reflection.Emit.ILGeneration\ref\netstandard1.0\System.Reflection.Emit.ILGeneration.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.ILGeneration">
+          <HintPath>..\..\packages\System.Reflection.Emit.ILGeneration\lib\netstandard1.3\System.Reflection.Emit.ILGeneration.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.Lightweight">
+          <HintPath>..\..\packages\System.Reflection.Emit.Lightweight\ref\netstandard1.0\System.Reflection.Emit.Lightweight.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.Lightweight">
+          <HintPath>..\..\packages\System.Reflection.Emit.Lightweight\lib\netstandard1.3\System.Reflection.Emit.Lightweight.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Extensions">
+          <HintPath>..\..\packages\System.Reflection.Extensions\ref\netstandard1.0\System.Reflection.Extensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Primitives">
+          <HintPath>..\..\packages\System.Reflection.Primitives.4.3\ref\netstandard1.0\System.Reflection.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\lib\netstandard1.5\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>..\..\packages\System.Reflection.TypeExtensions\ref\netstandard1.5\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Resources.ResourceManager">
+          <HintPath>..\..\packages\System.Resources.ResourceManager\ref\netstandard1.0\System.Resources.ResourceManager.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime">
+          <HintPath>..\..\packages\System.Runtime\ref\netstandard1.5\System.Runtime.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Extensions">
+          <HintPath>..\..\packages\System.Runtime.Extensions\ref\netstandard1.5\System.Runtime.Extensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Handles">
+          <HintPath>..\..\packages\System.Runtime.Handles.4.3\ref\netstandard1.3\System.Runtime.Handles.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices">
+          <HintPath>..\..\packages\System.Runtime.InteropServices.4.3\ref\netcoreapp1.1\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices">
+          <HintPath>..\..\packages\System.Runtime.InteropServices.4.3\ref\netstandard1.5\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Numerics">
+          <HintPath>..\..\packages\System.Runtime.Numerics\ref\netstandard1.1\System.Runtime.Numerics.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Numerics">
+          <HintPath>..\..\packages\System.Runtime.Numerics\lib\netstandard1.3\System.Runtime.Numerics.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3\ref\netstandard1.6\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Cng">
+          <HintPath>..\..\packages\System.Security.Cryptography.Cng.4.3\ref\netstandard1.6\System.Security.Cryptography.Cng.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Csp">
+          <HintPath>..\..\packages\System.Security.Cryptography.Csp.4.3\ref\netstandard1.3\System.Security.Cryptography.Csp.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Encoding">
+          <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3\ref\netstandard1.3\System.Security.Cryptography.Encoding.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.OpenSsl">
+          <HintPath>..\..\packages\System.Security.Cryptography.OpenSsl\lib\netstandard1.6\System.Security.Cryptography.OpenSsl.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.OpenSsl">
+          <HintPath>..\..\packages\System.Security.Cryptography.OpenSsl\ref\netstandard1.6\System.Security.Cryptography.OpenSsl.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Primitives">
+          <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3\lib\netstandard1.3\System.Security.Cryptography.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Primitives">
+          <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3\ref\netstandard1.3\System.Security.Cryptography.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.X509Certificates">
+          <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3\ref\netstandard1.4\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Text.Encoding">
+          <HintPath>..\..\packages\System.Text.Encoding.4.3\ref\netstandard1.3\System.Text.Encoding.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\ref\netcoreapp1.1\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\lib\netstandard1.6\System.Text.RegularExpressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\ref\netstandard1.6\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Threading">
+	        <HintPath>..\..\packages\System.Threading\lib\netstandard1.3\System.Threading.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading">
+          <HintPath>..\..\packages\System.Threading\ref\netstandard1.3\System.Threading.dll</HintPath>
+        </Reference>
+        <Reference Include="Threading.Tasks">
+          <HintPath>..\..\packages\Threading.Tasks\ref\netstandard1.0\Threading.Tasks.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Threading.Tasks">
+          <HintPath>..\..\packages\System.Threading.Tasks\ref\netstandard1.0\System.Threading.Tasks.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks">
+          <HintPath>..\..\packages\System.Threading.Tasks\ref\netstandard1.3\System.Threading.Tasks.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks.Parallel">
+          <HintPath>..\..\packages\System.Threading.Tasks.Parallel\ref\netstandard1.1\System.Threading.Tasks.Parallel.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks.Parallel">
+          <HintPath>..\..\packages\System.Threading.Tasks.Parallel\lib\netstandard1.3\System.Threading.Tasks.Parallel.dll</HintPath>
+        </Reference>
+        <Reference Include="Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Threading.Tasks.Extensions\lib\netstandard1.0\Threading.Tasks.Extensions.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\System.Threading.Tasks.Extensions\lib\netstandard1.0\System.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>..\..\packages\System.Threading.Thread\lib\netstandard1.3\System.Threading.Thread.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>..\..\packages\System.Threading.Thread\ref\netstandard1.3\System.Threading.Thread.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>..\..\packages\System.Threading.ThreadPool\lib\netstandard1.3\System.Threading.ThreadPool.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>..\..\packages\System.Threading.ThreadPool\ref\netstandard1.3\System.Threading.ThreadPool.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Timer">
+          <HintPath>..\..\packages\System.Threading.Timer\ref\netstandard1.2\System.Threading.Timer.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>

--- a/src/FsCheck.NUnit/FsCheck.NUnit.fsproj
+++ b/src/FsCheck.NUnit/FsCheck.NUnit.fsproj
@@ -79,6 +79,44 @@
   <Import Project="..\..\.paket\paket.targets" />
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.2'">
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="Threading.Tasks">
+          <HintPath>..\..\packages\Threading.Tasks\ref\netstandard1.0\Threading.Tasks.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
+      <ItemGroup>
+        <Reference Include="Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Threading.Tasks.Extensions\lib\netstandard1.0\Threading.Tasks.Extensions.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net20\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.0.3')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v5.0')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
@@ -126,7 +164,6 @@
       </ItemGroup>
     </When>
   </Choose>
-</Project>
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
       <ItemGroup>
@@ -799,7 +836,7 @@
     <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1'))">
       <ItemGroup>
         <Reference Include="System.Threading">
-	        <HintPath>..\..\packages\System.Threading\lib\netstandard1.3\System.Threading.dll</HintPath>
+          <HintPath>..\..\packages\System.Threading\lib\netstandard1.3\System.Threading.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -809,12 +846,6 @@
       <ItemGroup>
         <Reference Include="System.Threading">
           <HintPath>..\..\packages\System.Threading\ref\netstandard1.3\System.Threading.dll</HintPath>
-        </Reference>
-        <Reference Include="Threading.Tasks">
-          <HintPath>..\..\packages\Threading.Tasks\ref\netstandard1.0\Threading.Tasks.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Threading.Tasks">
-          <HintPath>..\..\packages\System.Threading.Tasks\ref\netstandard1.0\System.Threading.Tasks.dll</HintPath>
           <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
@@ -846,12 +877,6 @@
       <ItemGroup>
         <Reference Include="System.Threading.Tasks.Parallel">
           <HintPath>..\..\packages\System.Threading.Tasks.Parallel\lib\netstandard1.3\System.Threading.Tasks.Parallel.dll</HintPath>
-        </Reference>
-        <Reference Include="Threading.Tasks.Extensions">
-          <HintPath>..\..\packages\Threading.Tasks.Extensions\lib\netstandard1.0\Threading.Tasks.Extensions.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Threading.Tasks.Extensions">
-          <HintPath>..\..\packages\System.Threading.Tasks.Extensions\lib\netstandard1.0\System.Threading.Tasks.Extensions.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/FsCheck.netcore/FsCheck.netcore.fsproj
+++ b/src/FsCheck.netcore/FsCheck.netcore.fsproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>FsCheck</AssemblyName>
     <TargetFramework>netstandard1.6</TargetFramework>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FsCheck.XML</DocumentationFile>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\FsCheck\AssemblyInfo.fs">
       <Link>AssemblyInfo.fs</Link>
@@ -63,11 +61,10 @@
       <Link>RunnerExtensions.fs</Link>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-mergenupkg" Version="1.0.*" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
-
 </Project>

--- a/src/FsCheck/Common.fs
+++ b/src/FsCheck/Common.fs
@@ -3,7 +3,7 @@
 module internal Common =
 
     open System.Collections.Generic
-
+    
     ///Memoize the given function using the given dictionary
     let memoizeWith (memo:IDictionary<'a,'b>) (f: 'a -> 'b) =
         fun n ->

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -602,13 +602,14 @@ module Gen =
         let mapToInt (value:'a) =
             if isNull (box value) then 0
             else
-                let (found,result) = toCounter.TryGetValue value
-                if found then 
-                    result
-                else
-                    toCounter.Add(value,!counter)
-                    counter := !counter + 1
-                    !counter - 1
+                lock toCounter (fun _ ->
+                    let (found,result) = toCounter.TryGetValue value
+                    if found then 
+                        result
+                    else
+                        toCounter.Add(value,!counter)
+                        counter := !counter + 1
+                        !counter - 1)
         let rec rands r0 = seq { let r1,r2 = Random.split r0 in yield r1; yield! (rands r2) }
         fun (v:'a) (Gen m:Gen<'b>) -> Gen (fun n r -> m n (Seq.item ((mapToInt v)+1) (rands r)))
 

--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -1,4 +1,4 @@
-namespace FsCheck
+﻿namespace FsCheck
 
 open System
 
@@ -33,6 +33,11 @@ type IRunner =
     ///Called whenever all tests are done, either True, False or Exhausted.
     abstract member OnFinished: string * TestResult -> unit
 
+type ParallelRunConfig =
+    { // For I/O bound work 1 would be fine, for cpu intensive tasks Environment.ProcessorCount appears to be fastest option
+      MaxDegreeOfParallelism : int 
+    }
+
 ///For configuring a run.
 [<NoEquality;NoComparison>]
 type Config = 
@@ -59,10 +64,12 @@ type Config =
       ///overridden)
       Arbitrary     : list<Type>
       ///A custom test runner, e.g. to integrate with a test framework like xUnit or NUnit. 
-      Runner        : IRunner }
+      Runner        : IRunner
+      ///If set, inputs for property generation and property evaluation will be runned in parallel. 
+      ParallelRunConfig : ParallelRunConfig option
+    }
 
 module Runner =
-
     open System.Collections.Generic
     open System.Reflection
 
@@ -79,50 +86,263 @@ module Runner =
         | Shrink of Result          //shrunk falsified result succesfully
         | NoShrink of Result        //could not falsify given result; so unsuccesful shrink.
         | EndShrink of Result       //gave up shrinking; (possibly) shrunk result is given
-
+        
+    [<NoEquality;NoComparison>]
+    type private OutcomeSeqOrFuture =
+        | Value of seq<TestStep>
+        | Future of Threading.Tasks.Task<seq<TestStep>>
  
-    let rec private shrinkResult (result:Result) (shrinks:IEnumerator<Rose<Result>>) =
-        seq { if (shrinks.MoveNext()) then
+    let rec private shrinkResultValue (result :Result) (shrinks :IEnumerator<Rose<Result>>) =
+        seq { 
+            if (shrinks.MoveNext ()) then
                 //result forced here
                 let (MkRose ((Lazy result'),shrinks')) = shrinks.Current
-                if result'.Outcome.Shrink then yield Shrink result'; yield! shrinkResult result' (shrinks'.GetEnumerator())
-                else yield NoShrink result'; yield! shrinkResult result shrinks
-              else
-                yield EndShrink result
+                if result'.Outcome.Shrink then yield Shrink result'; yield! shrinkResultValue result' (shrinks'.GetEnumerator())
+                else yield NoShrink result'; yield! shrinkResultValue result shrinks
+            else yield EndShrink result
         }
-        
-    let rec private test initSize resize rnd0 ((Gen eval) as gen) =
-        seq { // would like to get rid of this split,
-              // but the problem is DiscardException. If it is thrown,
-              // we also don't get the the updated Rnd back from eval.
-              let rnd1,rnd2 = Random.split rnd0
-              let newSize = resize initSize
-              //printfn "Before generate"
-              //result forced here!
-              let result, shrinks =
-                  try
-                    let (MkRose (Lazy result,shrinks)) = (eval (newSize |> round |> int) rnd2).Value
+ 
+    let rec private shrinkResultTask (result :Result) (shrinks :IEnumerator<Rose<ResultContainer>>) =
+        let goNext (s :seq<Rose<ResultContainer>>) r = 
+            async {
+                if r.Outcome.Shrink then 
+                    let! xs = shrinkResultTask r (s.GetEnumerator ()) |> Async.AwaitTask
+                    return seq { yield Shrink r; yield! xs }
+                else 
+                    let! xs = shrinkResultTask result shrinks |> Async.AwaitTask
+                    return seq { yield NoShrink r; yield! xs }
+            }
+        if (shrinks.MoveNext ()) then
+            //result forced here
+            let (MkRose ((Lazy result'),shrinks')) = shrinks.Current
+            match result' with
+            | ResultContainer.Value r -> 
+                goNext shrinks' r |> Async.StartAsTask
+            | ResultContainer.Future t ->
+                let rt = t |> Async.AwaitTask
+                async.Bind (rt, goNext shrinks') |> Async.StartAsTask
+        else EndShrink result |> Seq.singleton |> Threading.Tasks.Task.FromResult
+
+    let private shrinkResultTaskIter (result: Result) (shrinks :IEnumerator<Rose<ResultContainer>>) =
+        let xs :Collections.Generic.List<TestStep> = ResizeArray () 
+        let rec iter (result: Result) (shrinks :IEnumerator<Rose<ResultContainer>>) =
+            if (shrinks.MoveNext ()) then
+                //result forced here
+                let (MkRose ((Lazy result'), shrinks')) = shrinks.Current
+                match result' with
+                | ResultContainer.Value r -> 
+                    if r.Outcome.Shrink then 
+                        xs.Add <| Shrink r
+                        iter r (shrinks'.GetEnumerator ())
+                    else
+                        xs.Add <| NoShrink r
+                        iter result shrinks
+                | ResultContainer.Future t ->
+                    async {
+                        let! rt = t |> Async.AwaitTask
+                        if rt.Outcome.Shrink then 
+                            let! ys = shrinkResultTask rt (shrinks'.GetEnumerator ()) |> Async.AwaitTask
+                            return seq { yield! xs; yield Shrink rt; yield! ys }
+                        else 
+                            let! ys = shrinkResultTask result shrinks |> Async.AwaitTask
+                            return seq { yield! xs; yield NoShrink rt; yield! ys }
+                    } |> Async.StartAsTask |> OutcomeSeqOrFuture.Future
+            else xs.Add <| EndShrink result; xs :> seq<_> |> OutcomeSeqOrFuture.Value
+        iter result shrinks
+
+    let private test initSize resize rnd0 gen =
+        let rec test' initSize resize rnd0 ((Gen eval) as gen) =
+            seq { 
+                let rnd1,rnd2 = Random.split rnd0
+                let newSize = resize initSize
+                //result forced here!
+                let result, shrinks =
+                    try
+                        let (MkRose (Lazy result, shrinks)) = (eval (newSize |> round |> int) rnd2).Value
+                        result, shrinks
+                        //printfn "After generate"
+                        //problem: since result.Ok is no longer lazy, we only get the generated args _after_ the test is run
+                    with :? DiscardException -> 
+                        Res.rejectedV, Seq.empty
+
+                yield Generated result.Arguments
+
+                match result.Outcome with
+                    | Outcome.Rejected -> 
+                        yield Failed result 
+                    | Outcome.True -> 
+                        yield Passed result
+                    | o when o.Shrink -> 
+                        yield Falsified result
+                        yield! shrinkResultValue result (shrinks.GetEnumerator ())
+                    | _ ->
+                        yield Falsified result
+                        yield EndShrink result
+                yield! test' newSize resize rnd1 gen
+            }
+        //Since we're not runing test for parallel scenarios it's impossible to discover `ResultContainer.Future` inside `result`
+        let gen' = gen |> Gen.map (Rose.map (fun rc -> match rc with 
+                | ResultContainer.Value r -> r 
+                | ResultContainer.Future t -> t.Result))
+        test' initSize resize rnd0 gen'
+
+    let private outcomeSeq result (shrinks :seq<_>) = 
+        let g = Generated result.Arguments
+        match result.Outcome with
+        | Outcome.Rejected -> 
+            seq {yield g; yield Failed result} |> OutcomeSeqOrFuture.Value
+        | Outcome.True -> 
+            seq {yield g; yield Passed result} |> OutcomeSeqOrFuture.Value
+        | o when o.Shrink -> 
+            match shrinkResultTaskIter result (shrinks.GetEnumerator ()) with
+            | OutcomeSeqOrFuture.Value v -> seq {yield g; yield Falsified result; yield! v} |> OutcomeSeqOrFuture.Value
+            | OutcomeSeqOrFuture.Future t -> t.ContinueWith (fun (xs :Threading.Tasks.Task<seq<TestStep>>) -> 
+                seq {yield g; yield Falsified result; yield! xs.Result}) |> OutcomeSeqOrFuture.Future         
+        | _ ->
+            seq {yield g; yield Falsified result; yield EndShrink result} |> OutcomeSeqOrFuture.Value
+
+    let private testStep rnd (size :float) ((Gen eval) as gen) =
+            let result, shrinks =
+                try
+                    let (MkRose (Lazy result, shrinks)) = (eval (size |> round |> int) rnd).Value
                     result, shrinks
-                    //printfn "After generate"
-                    //problem: since result.Ok is no longer lazy, we only get the generated args _after_ the test is run
-                  with :? DiscardException -> 
+                with :? DiscardException ->
                     Res.rejected, Seq.empty
 
-              yield Generated result.Arguments
+            match result with
+            | ResultContainer.Value r -> outcomeSeq r shrinks
+            | ResultContainer.Future t -> t.ContinueWith (fun (x :Threading.Tasks.Task<Result>) -> 
+                match outcomeSeq x.Result shrinks with
+                | OutcomeSeqOrFuture.Value v -> Threading.Tasks.Task.FromResult v
+                | OutcomeSeqOrFuture.Future t -> t) |> Threading.Tasks.TaskExtensions.Unwrap |> OutcomeSeqOrFuture.Future
 
-              match result.Outcome with
-                | Outcome.Rejected -> 
-                    yield Failed result 
-                | Outcome.True -> 
-                    yield Passed result
-                | o when o.Shrink -> 
-                    yield Falsified result
-                    yield! shrinkResult result (shrinks.GetEnumerator())
-                | _ ->
-                    yield Falsified result
-                    yield EndShrink result
-              yield! test newSize resize rnd1 gen
-        }
+    let stepsSeq resize =
+        Seq.unfold (fun (initSize, rnd) ->
+            let rnd1, rnd2 = Random.split rnd
+            let newSize = resize initSize
+            Some ((rnd1, rnd2, newSize), (newSize, rnd1)))
+
+    let private outcomeSeqFutureCont (xs :Threading.Tasks.Task<seq<TestStep>>) (state :obj) =
+        match state with 
+        | :? (int * Threading.CancellationToken * array<seq<TestStep>> * int) as state ->
+            let (j, ct, results, iters) = state
+            if (not ct.IsCancellationRequested) && j < iters then
+                results.[j] <- xs.Result
+        | _ -> raise (System.ArgumentException ("state"))
+
+#if PCL
+    let private parallelTest config = test
+#else
+    let private tpWorkerFun (state :obj) =
+        match state with 
+        | :? ((Rnd * Rnd * float) array * (int ref) * int * Gen<Rose<ResultContainer>> * array<seq<TestStep>> * Threading.CancellationToken) as state ->
+            let (steps, i, iters, gen, results, ct) = state
+            let mutable j = 0
+            while (not ct.IsCancellationRequested) && j < iters do
+                j <- Threading.Interlocked.Increment (i) - 1
+                if j < iters then
+                    let _, rnd, size = steps.[j]
+                    let res = testStep rnd size gen
+                    match res with
+                    | OutcomeSeqOrFuture.Value xs -> results.[j] <- xs
+                    | OutcomeSeqOrFuture.Future ts -> 
+                        ts.ContinueWith (outcomeSeqFutureCont, (j, ct, results, iters)) |> ignore                    
+        | _ -> raise (System.ArgumentException ("state"))
+
+    ///Enumerates over `steps` seq publishing every item to `tpWorkerFun` via `ThreadPool.QueueUserWorkItem`
+    ///Waits for `tpWorkerFun` to populate `results` array
+    ///Order is preserved by sitting in busy loop & checking current entry in `results` 
+    ///    and yielding processor to other threads if cell haven't been populated yet
+    ///To be lean in allocated space first assumes that test would pass and creates `result` of size `maxTest`
+    ///    reallocates `result` to hold `maxFail` entries if test is falsified
+    ///Other strategies can be considered to trade between allocated memory, overall running time and amount of cross-process communication:
+    ///    - publish to `tpWorkerFun` more than one entry at a time
+    ///    - allocate `results` in lesser chunks in iterative manner
+    ///    - change busy loop with yelding to waiting on conditional variables (tested, leads to slower runing time)
+    type private ParSeqEnumerator (steps :IEnumerable<(Rnd * Rnd * float)>, maxTest, maxFail, maxDegreeOfParallelism, gen) =   
+        let size = maxTest + maxFail
+        let luckySeq = steps |> Seq.take maxTest
+        let unluckySeq = steps |> Seq.skip maxTest |> Seq.take maxFail
+        let mutable results = Array.zeroCreate<seq<TestStep>> maxTest
+        let mutable i = 0
+        let indexT = ref 0
+        let indexF = ref 0
+        let mutable current = Unchecked.defaultof<TestStep>
+        let mutable subE = Linq.Enumerable.Empty<TestStep>().GetEnumerator ()
+        let mutable cts = new Threading.CancellationTokenSource ()
+        let mutable started = false
+        let mutable firstRun = true
+        let run xs index =
+            let xs = Array.ofSeq xs
+            for i in 0..(Math.Min (Array.length xs, maxDegreeOfParallelism)) do
+                Threading.ThreadPool.QueueUserWorkItem (
+                    new Threading.WaitCallback (tpWorkerFun),
+                    (xs, index, Array.length xs, gen, results, cts.Token)) |> ignore
+        let moveNextInner () = 
+            if subE.MoveNext () then
+                current <- subE.Current; true  
+            else
+                subE.Dispose (); false    
+        let moveNextOuter () =
+            if i = maxTest && firstRun then
+                results <- Array.zeroCreate<seq<TestStep>> maxFail
+                i <- 0
+                run unluckySeq indexF
+                firstRun <- false
+            while isNull results.[i] do
+                Threading.Thread.Yield () |> ignore
+            subE <- results.[i].GetEnumerator ()
+            i <- i + 1
+        interface IEnumerator<TestStep> with
+            member __.MoveNext () = 
+                if not started then
+                    run luckySeq indexT; started <- true
+                let mutable running = true
+                let mutable moved = false
+                while running do
+                    if i >= size then
+                        running <- false
+                    else
+                        if moveNextInner () then
+                            running <- false
+                            moved <- true
+                        else
+                            moveNextOuter ()
+                moved
+            member __.Current :TestStep = current
+            member __.Current :obj = box current
+            member __.Reset () = 
+                cts.Cancel ()
+                cts.Dispose ()
+                cts <- new Threading.CancellationTokenSource ()
+                started <- false
+                firstRun <- true
+                results <- Array.zeroCreate<seq<TestStep>> maxTest
+                current <- Unchecked.defaultof<TestStep>
+                i <- 0
+                indexT := 0
+                indexF := 0
+                subE.Dispose ()
+        interface IDisposable with
+            member __.Dispose () = 
+                cts.Cancel ()
+                subE.Dispose ()
+                cts.Dispose ()
+
+
+    type private ParTestSeq (steps, maxTest, maxFail, maxDegreeOfParallelism, gen) =   
+        let enumerator () = new ParSeqEnumerator (steps, maxTest, maxFail, maxDegreeOfParallelism, gen)
+        interface IEnumerable<TestStep> with
+            member __.GetEnumerator () = enumerator () :> IEnumerator<TestStep>
+            member __.GetEnumerator () = enumerator () :> System.Collections.IEnumerator
+
+    let private parallelTest config initSize resize rnd0 gen =
+        let steps = stepsSeq resize (initSize, rnd0)
+        let pd = Option.fold (fun _ pc -> if pc.MaxDegreeOfParallelism <> -1 then pc.MaxDegreeOfParallelism else Environment.ProcessorCount) 1 config.ParallelRunConfig
+        let parSeq = ParTestSeq (steps, config.MaxTest, config.MaxFail, pd, gen)
+        parSeq :> seq<_>
+#endif
+
 
     let private testsDone config testStep origArgs ntest nshrinks usedSeed stamps  =
         let entry (n,xs) = (100 * n / ntest),xs
@@ -144,19 +364,24 @@ module Runner =
                 | _ -> failwith "Test ended prematurely"
         config.Runner.OnFinished(config.Name,testResult)
 
+
     let private runner config prop = 
         let testNb = ref 0
         let failedNb = ref 0
         let shrinkNb = ref 0
         let tryShrinkNb = ref 0
         let origArgs = ref []
-        let lastStep = ref (Failed Res.rejected)
+        let lastStep = ref (Failed Res.rejectedV)
         let seed = match config.Replay with None -> Random.create() | Some s -> s
         let increaseSizeStep = float (config.EndSize - config.StartSize) / float config.MaxTest
-        test (float config.StartSize) ((+) increaseSizeStep) seed (property prop |> Property.GetGen) 
+        let testSeq = 
+            if config.ParallelRunConfig.IsSome then 
+                parallelTest config 
+             else 
+                test
+        testSeq (float config.StartSize) ((+) increaseSizeStep) seed (property prop |> Property.GetGen)
         |> Common.takeWhilePlusLast (fun step ->
             lastStep := step
-            //printfn "%A" step
             match step with
                 | Generated args -> config.Runner.OnArguments(!testNb, args, config.Every); true
                 | Passed _ -> testNb := !testNb + 1; !testNb <> config.MaxTest //stop if we have enough tests
@@ -335,7 +560,8 @@ type Config with
               Every         = fun _ _ -> String.Empty
               EveryShrink   = fun _ -> String.Empty
               Arbitrary     = []
-              Runner        = consoleRunner } 
+              Runner        = consoleRunner
+              ParallelRunConfig = None } 
 
     ///The verbose configuration prints each generated argument.
     static member Verbose = 

--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -290,7 +290,11 @@ module Runner =
                 run unluckySeq indexF
                 firstRun <- false
             while isNull results.[i] do
+#if NETSTANDARD1_6
+                Threading.Thread.Sleep (1) |> ignore
+#else
                 Threading.Thread.Yield () |> ignore
+#endif
             subE <- results.[i].GetEnumerator ()
             i <- i + 1
         interface IEnumerator<TestStep> with

--- a/src/FsCheck/RunnerExtensions.fs
+++ b/src/FsCheck/RunnerExtensions.fs
@@ -15,6 +15,7 @@ type Configuration() =
     let mutable quietOnSuccess = Config.Quick.QuietOnSuccess
     let mutable runner = Config.Quick.Runner
     let mutable replay = Config.Quick.Replay
+    let mutable parallelRunConfig = Config.Quick.ParallelRunConfig
 
     ///The quick configuration only prints a summary result at the end of the test.
     static member Quick = new Configuration()
@@ -76,6 +77,11 @@ type Configuration() =
     member __.Replay 
         with get() = (match replay with None -> Unchecked.defaultof<uint64*uint64> | Some s -> (s.Seed,s.Gamma))
         and set(v) = replay <- Some <| Random.createWithSeedAndGamma v
+        
+    ///If set, inputs for property generation and property evaluation will be runned in parallel.
+    member __.ParallelRunConfig 
+        with get() = (match parallelRunConfig with None -> Unchecked.defaultof<ParallelRunConfig> | Some c -> c)
+        and set(v) = parallelRunConfig <- Some <| v
 
     member internal __.ToConfig() =
         { MaxTest = maxTest
@@ -89,6 +95,7 @@ type Configuration() =
           Runner = runner
           Replay = replay
           Arbitrary = []
+          ParallelRunConfig = parallelRunConfig
         }
 
 

--- a/src/FsCheck/Testable.fs
+++ b/src/FsCheck/Testable.fs
@@ -1,5 +1,7 @@
 ﻿namespace FsCheck
 
+open System
+
 [<NoComparison; RequireQualifiedAccess>]
 type Outcome = 
     | Timeout of int
@@ -19,7 +21,7 @@ type Result =
         Arguments   : list<obj> } 
     ///Returns a new result that is Succeeded if and only if both this
     ///and the given Result are Succeeded.
-    static member (&&&) (l,r) = 
+    static member resAnd l r = 
         //printfn "And of l %A and r %A" l.Outcome r.Outcome
         match (l.Outcome,r.Outcome) with
         | (Outcome.Exception _,_) -> l //here a potential exception in r is thrown away...
@@ -31,7 +33,7 @@ type Result =
         | (_,Outcome.True) -> l
         | (Outcome.True,_) -> r
         | (Outcome.Rejected,Outcome.Rejected) -> l //or r, whatever
-    static member (|||) (l,r) =
+    static member resOr l r =
         match (l.Outcome, r.Outcome) with
         | (Outcome.Exception _,_) -> r
         | (_,Outcome.Exception _) -> l
@@ -43,24 +45,47 @@ type Result =
         | (_,Outcome.True) -> r
         | (Outcome.Rejected,Outcome.Rejected) -> l //or r, whatever
 
+type ResultContainer = 
+    | Value of Result
+    | Future of Threading.Tasks.Task<Result>
+    static member (&&&) (l,r) = 
+        //printfn "And of l %A and r %A" l.Outcome r.Outcome
+        match (l,r) with
+        | (Value vl,Value vr) -> Result.resAnd vl vr |> Value
+        | (Future tl,Value vr) -> tl.ContinueWith (fun (x :Threading.Tasks.Task<Result>) -> Result.resAnd x.Result vr) |> Future
+        | (Value vl,Future tr) -> tr.ContinueWith (fun (x :Threading.Tasks.Task<Result>) -> Result.resAnd x.Result vl) |> Future
+        | (Future tl,Future tr) -> tl.ContinueWith (fun (x :Threading.Tasks.Task<Result>) -> 
+            tr.ContinueWith (fun (y :Threading.Tasks.Task<Result>) -> Result.resAnd x.Result y.Result)) |> Threading.Tasks.TaskExtensions.Unwrap |> Future
+    static member (|||) (l,r) =
+        match (l,r) with
+        | (Value vl,Value vr) -> Result.resOr vl vr |> Value
+        | (Future tl,Value vr) -> tl.ContinueWith (fun (x :Threading.Tasks.Task<Result>) -> Result.resOr x.Result vr) |> Future
+        | (Value vl,Future tr) -> tr.ContinueWith (fun (x :Threading.Tasks.Task<Result>) -> Result.resOr x.Result vl) |> Future
+        | (Future tl,Future tr) -> tl.ContinueWith (fun (x :Threading.Tasks.Task<Result>) -> 
+            tr.ContinueWith (fun (y :Threading.Tasks.Task<Result>) -> Result.resOr x.Result y.Result)) |> Threading.Tasks.TaskExtensions.Unwrap |> Future
+
 module internal Res =
 
     let private result =
       { Outcome     = Outcome.Rejected
         Stamp       = []
-        Labels       = Set.empty
+        Labels      = Set.empty
         Arguments   = []
       }
 
-    let failed = { result with Outcome = Outcome.False }
+    let failed = { result with Outcome = Outcome.False } |> Value
 
-    let exc e = { result with Outcome = Outcome.Exception e }
+    let exc e = { result with Outcome = Outcome.Exception e } |> Value
 
-    let timeout i = { result with Outcome = Outcome.Timeout i }
+    let timeout i = { result with Outcome = Outcome.Timeout i } |> Value
 
-    let succeeded = { result with Outcome = Outcome.True }
+    let succeeded = { result with Outcome = Outcome.True } |> Value
 
-    let rejected = { result with Outcome = Outcome.Rejected }
+    let rejected = { result with Outcome = Outcome.Rejected } |> Value
+
+    let rejectedV = { result with Outcome = Outcome.Rejected }
+
+    let future (t :Threading.Tasks.Task<Outcome>) = t.ContinueWith (fun (x :Threading.Tasks.Task<Outcome>) -> { result with Outcome = x.Result }) |> Future
 
 //A rose is a pretty tree
 //Draw it and you'll see.
@@ -96,7 +121,7 @@ module internal Rose =
 
 
 ///A Property can be checked by FsCheck.
-type Property = private Property of Gen<Rose<Result>> with static member internal GetGen (Property g) = g
+type Property = private Property of Gen<Rose<ResultContainer>> with static member internal GetGen (Property g) = g
 
 module private Testable =
 
@@ -121,10 +146,20 @@ module private Testable =
     
         let ofRoseResult t : Property = Property <| gen { return t }
 
-        let ofResult (r:Result) : Property = 
+        let ofResult (r:ResultContainer) : Property = 
             ofRoseResult <| Rose.ret r
          
         let ofBool b = ofResult <| if b then Res.succeeded else Res.failed
+        
+        let ofTaskBool (b :Threading.Tasks.Task<bool>) = 
+            ofResult <| Res.future (b.ContinueWith (fun (x :Threading.Tasks.Task<bool>) -> 
+                if x.IsCompleted then
+                    if x.Result then Outcome.True else Outcome.False
+                else Outcome.Exception x.Exception))
+        
+        let ofTask (b :Threading.Tasks.Task) = 
+            ofResult <| Res.future (b.ContinueWith (fun (x :Threading.Tasks.Task) -> 
+                if x.IsCompleted then Outcome.True else Outcome.Exception x.Exception))
 
         let mapRoseResult f a = property a |> Property.GetGen |> Gen.map f |> Property
 
@@ -144,9 +179,13 @@ module private Testable =
         let rec props x = MkRose (lazy (property (pf x) |> Property.GetGen), shrink x |> Seq.map props |> Seq.cache)
         promoteRose (props x)
         |> Gen.map Rose.join
-     
+    
     let private evaluate body a =
-        let argument a res = { res with Arguments = (box a) :: res.Arguments }
+        let argument a res = match res with
+            | ResultContainer.Value r -> { r with Arguments = (box a) :: r.Arguments } |> Value
+            | ResultContainer.Future t -> t.ContinueWith (fun (rt :Threading.Tasks.Task<Result>) -> 
+                let r = rt.Result
+                { r with Arguments = (box a) :: r.Arguments }) |> Future
         //safeForce (lazy ( body a )) //this doesn't work - exception escapes??
         try 
             body a |> property
@@ -181,6 +220,18 @@ module private Testable =
         static member Bool() =
             { new Testable<bool> with
                 member __.Property b = Prop.ofBool b }
+        static member TaskBool() =
+            { new Testable<Threading.Tasks.Task<bool>> with
+                member __.Property b = Prop.ofTaskBool b }
+        static member Task() =
+            { new Testable<Threading.Tasks.Task> with
+                member __.Property b = Prop.ofTask b }
+        static member AsyncBool() =
+            { new Testable<Async<bool>> with
+                member __.Property b = Prop.ofTaskBool <| Async.StartAsTask b }
+        static member Async() =
+            { new Testable<Async<unit>> with
+                member __.Property b = Prop.ofTask <| Async.StartAsTask b }
         static member Lazy() =
             { new Testable<Lazy<'a>> with
                 member __.Property b =
@@ -189,7 +240,7 @@ module private Testable =
                     promoteLazy (lazy (Prop.safeForce b |> Property.GetGen)) |> Property } 
         static member Result() =
             { new Testable<Result> with
-                member __.Property res = Prop.ofResult res }
+                member __.Property res = Prop.ofResult <| Value res }
         static member Property() =
             { new Testable<Property> with
                 member __.Property prop = prop }
@@ -197,7 +248,7 @@ module private Testable =
             { new Testable<Gen<'a>> with
                 member __.Property gena = gen { let! a = gena in return! property a |> Property.GetGen } |> Property }
         static member RoseResult() =
-            { new Testable<Rose<Result>> with
+            { new Testable<Rose<ResultContainer>> with
                 member __.Property rosea = gen { return rosea } |> Property }
         static member Arrow() =
             { new Testable<('a->'b)> with

--- a/src/FsCheck/Testable.fs
+++ b/src/FsCheck/Testable.fs
@@ -241,6 +241,9 @@ module private Testable =
         static member Result() =
             { new Testable<Result> with
                 member __.Property res = Prop.ofResult <| Value res }
+        static member ResultContainer() =
+            { new Testable<ResultContainer> with
+                member __.Property resC = Prop.ofResult resC }
         static member Property() =
             { new Testable<Property> with
                 member __.Property prop = prop }

--- a/src/FsCheck/TypeClass.fs
+++ b/src/FsCheck/TypeClass.fs
@@ -91,6 +91,7 @@ module internal TypeClass =
 
         let instances = defaultArg instances Map.empty
         let keySet map = map |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+
         let memo = new Dictionary<_,_>() //should fix memo bug since the memo table is re-initialized when a new registration is done
          
         member __.Class = typedefof<'TypeClass>

--- a/tests/FsCheck.Test/Property.fs
+++ b/tests/FsCheck.Test/Property.fs
@@ -58,25 +58,25 @@ module Property =
         let addStamp stamp res = { res with Stamp = stamp :: res.Stamp }
         let addArgument arg res = { res with Arguments = arg :: res.Arguments }
         let addLabel label (res:Result) = { res with Labels = Set.add label res.Labels }
-        let andCombine prop1 prop2 :Result = let (r1:Result,r2) = determineResult prop1, determineResult prop2 in r1 &&& r2
+        let andCombine prop1 prop2 :Result = let (r1:Result,r2) = determineResult prop1, determineResult prop2 in Result.resAnd r1 r2
         match prop with
-        | Unit ->   { result with Outcome=Outcome.True }
-        | Bool true -> { result with Outcome=Outcome.True }
-        | Bool false -> { result with Outcome=Outcome.False }
-        | Exception  -> { result with Outcome=Outcome.Exception (InvalidOperationException() :> exn)}
+        | Unit ->   { result with Outcome= Outcome.True }
+        | Bool true -> { result with Outcome= Outcome.True }
+        | Bool false -> { result with Outcome= Outcome.False }
+        | Exception  -> { result with Outcome= Outcome.Exception (InvalidOperationException() :> exn)}
         | ForAll (i,prop) -> determineResult prop |> addArgument i
         | Implies (true,prop) -> determineResult prop
-        | Implies (false,_) -> { result with Outcome=Outcome.Rejected }
+        | Implies (false,_) -> { result with Outcome= Outcome.Rejected }
         | Classify (true,stamp,prop) -> determineResult prop |> addStamp stamp
         | Classify (false,_,prop) -> determineResult prop
         | Collect (i,prop) -> determineResult prop |> addStamp (sprintf "%A" i)
         | Label (l,prop) -> determineResult prop |> addLabel l
         | And (prop1, prop2) -> andCombine prop1 prop2
-        | Or (prop1, prop2) -> let r1,r2 = determineResult prop1, determineResult prop2 in r1 ||| r2
+        | Or (prop1, prop2) -> let r1,r2 = determineResult prop1, determineResult prop2 in Result.resOr r1 r2
         | LazyProp prop -> determineResult prop
         | Tuple2 (prop1,prop2) -> andCombine prop1 prop2
-        | Tuple3 (prop1,prop2,prop3) -> (andCombine prop1 prop2) &&& (determineResult prop3)
-        | List props -> List.fold (fun st p -> st &&& determineResult p) (List.head props |> determineResult) (List.tail props)
+        | Tuple3 (prop1,prop2,prop3) -> Result.resAnd (andCombine prop1 prop2) (determineResult prop3)
+        | List props -> List.fold (fun st p -> Result.resAnd st (determineResult p)) (List.head props |> determineResult) (List.tail props)
         
     let rec private toProperty prop =
         match prop with
@@ -145,7 +145,7 @@ module Property =
         Prop.forAll (Arb.fromGen symPropGen) (fun symprop ->
             let expected = determineResult symprop
             let resultRunner = GetResultRunner()
-            let config = { Config.Quick with Runner = resultRunner; MaxTest = 2  }
+            let config = { Config.Quick with Runner = resultRunner; MaxTest = 2; }
             Check.One(config,toProperty symprop)
             let actual = resultRunner.Result
             areSame expected actual

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -1,5 +1,150 @@
 ﻿namespace FsCheck.Test
 
+module RunnerInternals =
+
+    open System
+    open Xunit
+    open FsCheck
+    open FsCheck.Runner
+    open System.Linq
+    open FsCheck.Xunit
+
+    type ProbeRunner () =
+        let mutable result = None
+        let sink :Collections.Generic.List<obj> = ResizeArray ()
+        let cmpTestData = function 
+            { NumberOfTests = nt1; NumberOfShrinks = ns1; Stamps = sx1; Labels = lx1 }, 
+            { NumberOfTests = nt2; NumberOfShrinks = ns2; Stamps = sx2; Labels = lx2 } -> 
+                nt1 = nt2 && ns1 = ns2 && Enumerable.SequenceEqual (sx1, sx2) && Enumerable.SequenceEqual (lx1, lx2)
+        let cmpOutcome = function
+            | Outcome.Timeout _, Outcome.Timeout _ -> true
+            | Outcome.Exception ex1, Outcome.Exception ex2 -> ex1.Equals ex2
+            | Outcome.False, Outcome.False -> true
+            | Outcome.True, Outcome.True -> true
+            | Outcome.Rejected, Outcome.Rejected -> true
+            | _, _ -> false
+        member __.Result = result.Value
+        member __.Sink = sink
+        override __.Equals other =
+            match other with
+            | :? ProbeRunner as pr -> 
+                let resultEq = 
+                    match pr.Result, __.Result with
+                    | TestResult.True (td1, so1), TestResult.True (td2, so2) -> 
+                        so1 = so2 && cmpTestData (td1, td2)
+                    | TestResult.False (td1, oa1, sa1, o1, r1), TestResult.False (td2, oa2, sa2, o2, r2) -> 
+                        cmpTestData (td1, td2) && 
+                        cmpOutcome (o1, o2) && 
+                        Enumerable.SequenceEqual (oa1, oa2) && 
+                        Enumerable.SequenceEqual (sa1, sa2) &&
+                        r1 = r2
+                    | TestResult.Exhausted td1, TestResult.Exhausted td2 -> cmpTestData (td1, td2)
+                    | _, _-> false
+                resultEq && Enumerable.SequenceEqual (pr.Sink, sink)
+            | _ -> false
+        interface IRunner with
+            override __.OnStartFixture _ = ()
+            override __.OnArguments (ntest, args, _) = 
+                sink.Add ntest
+                sink.AddRange args
+            override __.OnShrink(args, _) = 
+                sink.Add -1
+                sink.AddRange args
+            override __.OnFinished(_, testResult) = 
+                result <- Some testResult
+
+
+    let check arb body config =
+        let p = Prop.forAll arb body
+        let seed = Random.create () |> Some
+        printfn "seed %A" seed
+        let runner1 = ProbeRunner () 
+        FsCheck.Runner.check { config with Replay = seed; Runner = runner1; ParallelRunConfig = Some { MaxDegreeOfParallelism = Environment.ProcessorCount } } p
+        let runner2 = ProbeRunner () 
+        FsCheck.Runner.check { config with Replay = seed; Runner = runner2; ParallelRunConfig = None } p
+        runner1.Equals runner2
+            
+    [<Fact>]
+    let ``parallelTest produces same sequence as test on success`` () =
+        let body i = true
+        let arb = Arb.from<int>
+        let config = { Config.Quick with MaxTest = 30000; EndSize = 30000 }
+        if not <| check arb body config then failwith "can't find the way to call xunit assertion lol"
+
+    [<Fact>]
+    let ``parallelTest produces same sequence as test on failure`` () =
+        let body i = i < 999
+        let arb = Arb.from<int>
+        let config = { Config.Quick with MaxTest = 30000; EndSize = 30000 }
+        if not <| check arb body config then failwith "can't find the way to call xunit assertion lol"
+            
+    [<Fact>]
+    let ``parallelTest produces same sequence as test on discard`` () =
+        let body _ = true
+        let arb = Arb.fromGen (Gen.constant 1 |> Gen.map (fun _ -> Prop.discard ()))
+        let config = { Config.Quick with MaxTest = 30000; MaxFail = 100000; EndSize = 30000 }
+        if not <| check arb body config then failwith "can't find the way to call xunit assertion lol"
+    
+    type Tree = Leaf of int | Branch of Tree * Tree
+    
+    let tree =
+        let rec tree' s = 
+            match s with
+            | 0 -> Gen.map Leaf Arb.generate<int>
+            | n when n>0 -> 
+                let subtree = tree' (n/2)
+                Gen.oneof [ Gen.map Leaf Arb.generate<int> 
+                            Gen.map2 (fun x y -> Branch (x,y)) subtree subtree]
+            | _ -> invalidArg "s" "Only positive arguments are allowed"
+        Gen.sized tree'
+        
+    type TreeGen =
+        static member Tree() =
+            {new Arbitrary<Tree>() with
+                override x.Generator = tree
+                override x.Shrinker t = Seq.empty }
+
+    [<Fact>]
+    let ``parallelTest works with custom arb`` () =
+        Arb.register<TreeGen> ()
+        let arb = Arb.from<list<Tree>>
+        let body (xs:list<Tree>) = List.rev(List.rev xs) = xs
+        let config = { Config.Quick with MaxTest = 3000; EndSize = 3000 }
+        if not <| check arb body config then failwith "not threadsafe"
+    
+    type Integer = Integer of int
+    
+    let integer =
+        let mutable i = 0
+        let rec integer' s = 
+            i <- i + s // breaking thread safety
+            Integer i |> gen.Return
+        Gen.sized integer'
+        
+    type IntegerGen =
+        static member Integer() =
+            {new Arbitrary<Integer>() with
+                override x.Generator = integer
+                override x.Shrinker t = Seq.empty }
+
+    [<Fact>]
+    let ``parallelTest doesnt works with custom non threadsafe arb`` () =
+        Arb.register<IntegerGen> ()
+        let body i = true
+        let arb = Arb.from<Integer>
+        let config = { Config.Quick with MaxTest = 300000; EndSize = 300000 }
+        if check arb body config then failwith "can't be"
+
+    [<Property(Replay = "10538531436017130025,14826463994991344553", MaxTest = 30000, EndSize = 30000)>]
+    let ``30k ints fails`` () =
+        true
+        
+    [<Fact>]
+    let ``bad case`` () = 
+        let rnd = Random.createWithSeedAndGamma (13471455474525100574UL,7555858534656909083UL)
+        let n = 19938
+        Random.rangeInt (0, n, rnd)
+
 module Runner =
 
     open System
@@ -202,7 +347,7 @@ module BugReproIssue344 =
             
         // run this on another thread, and abort it manually
         let thread2 = Thread(fun () ->
-            let config = { Config.Quick with Arbitrary = [ typeof<MyGenerators> ]  }
+            let config = { Config.Quick with Arbitrary = [ typeof<MyGenerators> ]; ParallelRunConfig = None }
             Check.One(config, fun (x:IntWrapper) -> 
                 // fail the first iteration
                 if x.I = 1 then

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -69,21 +69,21 @@ module RunnerInternals =
         let body i = true
         let arb = Arb.from<int>
         let config = { Config.Quick with MaxTest = 30000; EndSize = 30000 }
-        if not <| check arb body config then failwith "can't find the way to call xunit assertion lol"
+        if not <| check arb body config then failwith "assertion failure!"
 
     [<Fact>]
     let ``parallelTest produces same sequence as test on failure`` () =
         let body i = i < 999
         let arb = Arb.from<int>
         let config = { Config.Quick with MaxTest = 30000; EndSize = 30000 }
-        if not <| check arb body config then failwith "can't find the way to call xunit assertion lol"
+        if not <| check arb body config then failwith "assertion failure!"
             
     [<Fact>]
     let ``parallelTest produces same sequence as test on discard`` () =
         let body _ = true
         let arb = Arb.fromGen (Gen.constant 1 |> Gen.map (fun _ -> Prop.discard ()))
         let config = { Config.Quick with MaxTest = 30000; MaxFail = 100000; EndSize = 30000 }
-        if not <| check arb body config then failwith "can't find the way to call xunit assertion lol"
+        if not <| check arb body config then failwith "assertion failure!"
     
     type Tree = Leaf of int | Branch of Tree * Tree
     
@@ -133,17 +133,7 @@ module RunnerInternals =
         let body i = true
         let arb = Arb.from<Integer>
         let config = { Config.Quick with MaxTest = 300000; EndSize = 300000 }
-        if check arb body config then failwith "can't be"
-
-    [<Property(Replay = "10538531436017130025,14826463994991344553", MaxTest = 30000, EndSize = 30000)>]
-    let ``30k ints fails`` () =
-        true
-        
-    [<Fact>]
-    let ``bad case`` () = 
-        let rnd = Random.createWithSeedAndGamma (13471455474525100574UL,7555858534656909083UL)
-        let n = 19938
-        Random.rangeInt (0, n, rnd)
+        if check arb body config then failwith "assertion failure!"
 
 module Runner =
 


### PR DESCRIPTION
Do not merge.

Here is PoC for #83 
This PR introduces ability to run generation and checks in parallel through pluggable function [`parallelTest`](https://github.com/Rattenkrieg/FsCheck/blob/parallel-run-83/src/FsCheck/Runner.fs#L129)
 which is parallel version of [`test`](https://github.com/Rattenkrieg/FsCheck/blob/parallel-run-83/src/FsCheck/Runner.fs#L129)
Currently PLINQ is used as engine for parallel execution - choosen because it comes with framework and there is almost one-to-one translation of sequential routines. But any other options are welcomed.
Obviously there is now requirement on _Gens_ and properties to be thread-safe, so `StateMachine` and model-based tests should be runned in sequential mode.

Currently all tests are passing. Except `FsCheck.Experimental.Test.StateMachine` (surprisingly only one).
Although there is performance degradation due to scheduling overhead on default 100 passes, yet on 1000 passes running every test in parallel mode yields faster timings comparing to sequential

I will provide benchmarks using compute-bound _Gens_ and properties as well as properties with simulation of IO-bound work.

- [x] PoC for generating input and running properties in parallel
- [x] Ordering guarantees are consistent with sequential runner, we may want to provide ability to loosen it in favor of better performance through config
- [x] Find way to run tests without breaking incapsulation (maybe custom `IRunner`)
- [ ] Elaborate on whether to expose more tweaks through config (like degree of parallelism, order preservation etc)
- [x] True parallelism for asyncs/tasks
- [x] Benchmarks