### PR TITLE
Random now correctly updates rng (fix for #356)

### DIFF
--- a/tests/FsCheck.Test/Random.fs
+++ b/tests/FsCheck.Test/Random.fs
@@ -18,4 +18,13 @@ module Random =
         Random.createWithSeed UInt64.MinValue |> ignore
         Random.createWithSeed UInt64.MaxValue |> ignore
         
+    // theese tests may be helpful to check Random progress guarantees. See #356
+    [<Property(Replay = "10538531436017130025,14826463994991344553", MaxTest = 30000, EndSize = 30000)>]
+    let ``Random should not hang on 30k ints`` () =
+        true
 
+    [<Fact>]
+    let ``Random should not hang on bad case`` () = 
+        let rnd = Random.createWithSeedAndGamma (13471455474525100574UL,7555858534656909083UL)
+        let n = 19938
+        Random.rangeInt (0, n, rnd)


### PR DESCRIPTION
Found no usage of first param to `next*` functions, so I have removed it.
Just to note - F# compiler surprisingly not giving error when I'm not assigning value to out param.