### PR TITLE
support C# DTO in reflection based generators

### DIFF
--- a/docs/content/TestData.fsx
+++ b/docs/content/TestData.fsx
@@ -532,7 +532,7 @@ aggressive, consider using `Gen.tryFilter` instead of `Gen.filter`.
 FsCheck defines default test data generators and shrinkers for some often used types, for example
 unit, bool, byte, int, float, char, string, DateTime, lists, array 1D and 2D, Set, Map, objects and 
 functions from and to any of the above. Furthermore, by using reflection, FsCheck can derive 
-default implementations of record types, discriminated unions, tuples, enums and basic immutable classes in terms 
+default implementations of record types, discriminated unions, tuples, enums and basic classes in terms 
 of any primitive types that are defined (either in FsCheck or by you).
 
 You do not need to define these explicity for every property: FsCheck can provide a property with 

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -1114,8 +1114,9 @@ module Arb =
             
         ///Try to derive an arbitrary instance for the given type reflectively. 
         ///Generates and shrinks values for record, union, tuple and enum types.
-        ///Also generates (but doesn't shrink) values for immutable classes 
-        ///(i.e. single constructor, no mutable properties or fields).
+        ///Also generates (but doesn't shrink) values for basic classes 
+        ///(i.e. either classes having a single constructor with immutable values  
+        ///or DTO classes with a default constructor and public property setters).
         static member Derive() =
             //taking out this generator makes sure that the memoization table in reflectGenObj
             //is used properly.

--- a/src/FsCheck/ReflectArbitrary.fs
+++ b/src/FsCheck/ReflectArbitrary.fs
@@ -109,6 +109,14 @@ module internal ReflectArbitrary =
             let g = productGen fields create
             box g
 
+        elif isCSharpDtoType t then
+            let fields = getCSharpDtoFields t
+            if fields |> Seq.exists ((=) t) then 
+                failwithf "Recursive record types cannot be generated automatically: %A" t 
+            let create = getCSharpDtoConstructor t
+            let g = productGen fields create
+            box g
+
         else
             failwithf "The type %s is not handled automatically by FsCheck. Consider using another type or writing and registering a generator for it." t.FullName
                 

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -537,6 +537,17 @@ module Arbitrary =
     let ``Derive generator for concrete class with one constructor with two parameters``() =
         generate<FakeRecord> |> sample 10 |> ignore
 
+    type FakeDto() =
+        member val A = Unchecked.defaultof<string> with get, set
+        member val B = Unchecked.defaultof<int> with get, set
+        member val C = Unchecked.defaultof<System.Nullable<int>> with get, set
+        member val D = Unchecked.defaultof<ResizeArray<string>> with get, set
+
+    [<Fact>]
+    let ``Derive generator for concrete DTO class with writable properties``() =
+        generate<FakeDto> |> sample 10 |> ignore
+
+
     type PrivateRecord = private { a: int; b: string }
 
     [<Fact>]


### PR DESCRIPTION
this PR is related to #367: support for DTO classes is kept separate from existing support for C# record classes.
A DTO is a class with the default (parameterless) constructor as the only public constructor and having some writable public property. For each writable public property a randomly generated value is set, using a member init expression.
This PR may be enhanced with some unit test (I could not find any existing test related to reflection based generation) and also adjusting docs (where it is stated that only immutable classes are supported).

