### PR TITLE
Added Gen.optionOf

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -483,7 +483,7 @@ module Arb =
         ///Generate an option value that is 'None' 1/8 of the time.
         static member Option() = 
             { new Arbitrary<option<'a>>() with
-                override __.Generator = Gen.frequency [(1, gen { return None }); (7, Gen.map Some generate)]
+                override __.Generator = Gen.optionOf generate
                 override __.Shrinker o =
                     match o with
                     | Some x -> seq { yield None; for x' in shrink x -> Some x' }

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -550,7 +550,11 @@ module Gen =
                   let! rows = chooseSqrtOfSize 
                   let! cols = chooseSqrtOfSize
                   return! array2DOfDim (rows,cols) g }
-        
+
+    ///Generate an option value that is 'None' 1/8 of the time.
+    //[category: Creating generators from generators]
+    let optionOf g = frequency [(1, gen { return None }); (7, map Some g)]
+
     ///Always generate the same instance v. See also fresh.
     //[category: Creating generators]
     [<CompiledName("Constant")>]


### PR DESCRIPTION
The implementation is essentially a copy of Arb.Default.Option(), which
now calls into Gen.optionOf. While there's a single test of
Arb.Default.Option(), that test doesn't really verify anything. I could
replace the Generator implementation with ` Gen.constant None` without
breaking any tests. This I describe only to defend that this commit,
which adds a new feature, adds no new tests. I can't, however, think of
an appropriate way to test Gen.optionOf in any meaningful way.
Apparently, the author of Arb.Default.Option() couldn't, as well.

The name is chosen to mirror Gen.listOf, Gen.arrayOf, and so on.