### PR TITLE
Remove Gen.eval and refactor Gen.sample

### DIFF
--- a/examples/FsCheck.CSharpExamples/Program.cs
+++ b/examples/FsCheck.CSharpExamples/Program.cs
@@ -178,6 +178,9 @@ namespace FsCheck.CSharpExamples
                             a.Except(b).Count() <= a.Count())
                 .QuickCheck();
 
+            Arb.Generate<int>().Sample(10);
+            Arb.Generate<int>().Sample(10, size:25);
+
             Console.ReadKey();
         }
 

--- a/examples/FsCheck.Examples/Examples.fs
+++ b/examples/FsCheck.Examples/Examples.fs
@@ -10,7 +10,7 @@ open System.Collections.Generic
 open Prop
 
 //init bug
-let sizedString =  Arb.generate<char> |> Gen.sample 10 10
+let sizedString =  Arb.generate<char> |> Gen.sample 10
     
 
 //---too early initialization bug (put this first): fixed---

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -155,20 +155,15 @@ module Gen =
     [<CompiledName("Resize")>]
     let resize newSize (Gen m) = Gen (fun _ r -> m newSize r)
 
-    ///Generates a value of the give size with the given seed.
-    //[category: Generating test values]
-    [<CompiledName("Eval")>]
-    let eval n rnd (Gen m) = 
-        let size,rnd' = Random.rangeInt (0, n, rnd)
-        (m size rnd').Value
-
     ///Generates n values of the given size.
     //[category: Generating test values]
     [<CompiledName("Sample")>]
-    let sample size n generator  = 
+    let sample size n (Gen generator)  = 
         let rec sample i seed samples =
             if i = 0 then samples
-            else sample (i-1) (Random.split seed |> snd) (eval size seed generator :: samples)
+            else
+                let sv = generator size seed
+                sample (i-1) sv.UpdatedState (sv.Value :: samples)
         sample n (Random.create()) []
 
     ///Generates an integer between l and h, inclusive.

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -155,16 +155,26 @@ module Gen =
     [<CompiledName("Resize")>]
     let resize newSize (Gen m) = Gen (fun _ r -> m newSize r)
 
-    ///Generates n values of the given size.
+    ///Generates n values of the given size and starting with the given seed.
     //[category: Generating test values]
     [<CompiledName("Sample")>]
-    let sample size n (Gen generator)  = 
+    let sampleWithSeed seed size nbSamples (Gen generator)  = 
         let rec sample i seed samples =
             if i = 0 then samples
             else
                 let sv = generator size seed
                 sample (i-1) sv.UpdatedState (sv.Value :: samples)
-        sample n (Random.create()) []
+        sample nbSamples seed []
+
+    ///Generates a given number of values with a new seed and a given size.
+    //[category: Generating test values]
+    [<CompiledName("Sample")>]
+    let sampleWithSize size nbSamples gen = sampleWithSeed (Random.create()) size nbSamples gen
+
+    ///Generates a given number of values with a new seed and a size of 50.
+    //[category: Generating test values]
+    [<CompiledName("Sample")>]
+    let sample nbSamples gen = sampleWithSize 50 nbSamples gen
 
     ///Generates an integer between l and h, inclusive.
     //[category: Creating generators]

--- a/src/FsCheck/GenExtensions.fs
+++ b/src/FsCheck/GenExtensions.fs
@@ -8,12 +8,6 @@ open System.Collections.Generic
 [<AbstractClass; Sealed; System.Runtime.CompilerServices.Extension>]
 type GenExtensions = 
 
-    ///Generates a value with maximum size n.
-    //[category: Generating test values]
-    [<System.Runtime.CompilerServices.Extension>]
-    static member Eval(generator, size, random) =
-        eval size random generator
-
     ///Generates n values of the given size.
     //[category: Generating test values]
     [<System.Runtime.CompilerServices.Extension>]

--- a/src/FsCheck/GenExtensions.fs
+++ b/src/FsCheck/GenExtensions.fs
@@ -3,17 +3,19 @@
 open Gen
 open System
 open System.Collections.Generic
+open System.Runtime.InteropServices
 
 ///Extension methods to build generators - contains among other the Linq methods.
 [<AbstractClass; Sealed; System.Runtime.CompilerServices.Extension>]
 type GenExtensions = 
 
-    ///Generates n values of the given size.
+ #if !PCL
+    ///Generates numberOfSample values with the given (optional) seed and of the given (optional) size, which defaults to 50.
     //[category: Generating test values]
     [<System.Runtime.CompilerServices.Extension>]
-    static member Sample(generator, size, numberOfSamples) =
-        sample size numberOfSamples generator
-
+    static member Sample(generator, numberOfSamples, [<DefaultParameterValue(Nullable<Rnd>());Optional>] seed:Nullable<Rnd>, [<DefaultParameterValue(50);Optional>] size) =
+        sampleWithSeed (if seed.HasValue then seed.Value else Random.create()) size numberOfSamples generator
+#endif
     /// Allows type annotations in LINQ expressions
     [<System.Runtime.CompilerServices.Extension>]
     static member Cast(g:Gen<_>) = g

--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -91,14 +91,17 @@ module Runner =
                 yield EndShrink result
         }
         
-    let rec private test initSize resize rnd0 gen =
-        seq { let rnd1,rnd2 = Random.split rnd0
+    let rec private test initSize resize rnd0 ((Gen eval) as gen) =
+        seq { // would like to get rid of this split,
+              // but the problem is DiscardException. If it is thrown,
+              // we also don't get the the updated Rnd back from eval.
+              let rnd1,rnd2 = Random.split rnd0
               let newSize = resize initSize
               //printfn "Before generate"
               //result forced here!
               let result, shrinks =
                   try
-                    let (MkRose (Lazy result,shrinks)) = Gen.eval (newSize |> round |> int) rnd2 gen
+                    let (MkRose (Lazy result,shrinks)) = (eval (newSize |> round |> int) rnd2).Value
                     result, shrinks
                     //printfn "After generate"
                     //problem: since result.Ok is no longer lazy, we only get the generated args _after_ the test is run

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -357,7 +357,7 @@ module Gen =
                   return !s
                 }
         test <@ convolutedGenNumber 100 
-                |> Gen.sample 1 10
+                |> Gen.sample 10
                 |> Seq.forall ((=) 100) @>
 
     [<Fact>]
@@ -370,7 +370,7 @@ module Gen =
                   return !s
                 }
         test <@ convolutedGenNumber 100 
-                |> Gen.sample 1 10
+                |> Gen.sample 10
                 |> Seq.forall ((=) 100) @>
 
 
@@ -396,9 +396,9 @@ module Gen =
         // type Tree = T of Tree * Tree |  Branch of int
         // whereas as the example demonstrates recursion can be
         // more involved.
-        let r1 = Gen.sample 100 100 (Arb.Default.Derive<MyRecord>().Generator)
-        let r2 = Gen.sample 100 100 (Arb.Default.Derive<MyUnion>().Generator)
-        let r3 = Gen.sample 100 100 (Arb.Default.Derive<MyOtherUnion>().Generator)
+        let r1 = Gen.sampleWithSize 100 100 (Arb.Default.Derive<MyRecord>().Generator)
+        let r2 = Gen.sampleWithSize 100 100 (Arb.Default.Derive<MyUnion>().Generator)
+        let r3 = Gen.sampleWithSize 100 100 (Arb.Default.Derive<MyOtherUnion>().Generator)
         test <@ r1.Length + r2.Length + r3.Length = 300 @>
 
 
@@ -433,30 +433,29 @@ module Gen =
 
     [<Fact>]
     let ``generate FSharpLu test types``() =
-        let size = 25
         let times = 10000
-        let r = Gen.sample size times Arb.generate<ComplexDu>
-        let r = Gen.sample size times Arb.generate<ComplexDu RecursiveList>
-        let r = Gen.sample size times Arb.generate<WithFields>
-        let r = Gen.sample size times Arb.generate<SimpleDu>
-        let r = Gen.sample size times Arb.generate<ComplexDu>
-        let r = Gen.sample size times Arb.generate<OptionOfBase>
-        let r = Gen.sample size times Arb.generate<OptionOfDu>
-        let r = Gen.sample size times Arb.generate<Color>
-        let r = Gen.sample size times Arb.generate<Shape>
-        let r = Gen.sample size times Arb.generate<int Tree>
-        let r = Gen.sample size times Arb.generate<int Tree Test>
-        let r = Gen.sample size times Arb.generate<int Test>
-        let r = Gen.sample size times Arb.generate<int list Tree>
-        let r = Gen.sample size times Arb.generate<string NestedOptions>
-        let r = Gen.sample size times Arb.generate<string>
-        let r = Gen.sample size times Arb.generate<string option>
-        let r = Gen.sample size times Arb.generate<string option option>
-        let r = Gen.sample size times Arb.generate<string option option option option>
-        let r = Gen.sample size times Arb.generate<int NestedOptions>
-        let r = Gen.sample size times Arb.generate<SomeAmbiguity.Ambiguous1<string>>
-        let r = Gen.sample size times Arb.generate<SomeAmbiguity.Ambiguous1<SimpleDu>>
-        let r = Gen.sample size times Arb.generate<NestedOptionStructure>
-        let r = Gen.sample size times Arb.generate<SomeAmbiguity.Ambiguous2>
-        let r = Gen.sample size times Arb.generate<SomeAmbiguity.Ambiguous3>
+        let r = Gen.sample times Arb.generate<ComplexDu>
+        let r = Gen.sample times Arb.generate<ComplexDu RecursiveList>
+        let r = Gen.sample times Arb.generate<WithFields>
+        let r = Gen.sample times Arb.generate<SimpleDu>
+        let r = Gen.sample times Arb.generate<ComplexDu>
+        let r = Gen.sample times Arb.generate<OptionOfBase>
+        let r = Gen.sample times Arb.generate<OptionOfDu>
+        let r = Gen.sample times Arb.generate<Color>
+        let r = Gen.sample times Arb.generate<Shape>
+        let r = Gen.sample times Arb.generate<int Tree>
+        let r = Gen.sample times Arb.generate<int Tree Test>
+        let r = Gen.sample times Arb.generate<int Test>
+        let r = Gen.sample times Arb.generate<int list Tree>
+        let r = Gen.sample times Arb.generate<string NestedOptions>
+        let r = Gen.sample times Arb.generate<string>
+        let r = Gen.sample times Arb.generate<string option>
+        let r = Gen.sample times Arb.generate<string option option>
+        let r = Gen.sample times Arb.generate<string option option option option>
+        let r = Gen.sample times Arb.generate<int NestedOptions>
+        let r = Gen.sample times Arb.generate<SomeAmbiguity.Ambiguous1<string>>
+        let r = Gen.sample times Arb.generate<SomeAmbiguity.Ambiguous1<SimpleDu>>
+        let r = Gen.sample times Arb.generate<NestedOptionStructure>
+        let r = Gen.sample times Arb.generate<SomeAmbiguity.Ambiguous2>
+        let r = Gen.sample times Arb.generate<SomeAmbiguity.Ambiguous3>
         ()

--- a/tests/FsCheck.Test/Helpers.fs
+++ b/tests/FsCheck.Test/Helpers.fs
@@ -8,7 +8,7 @@ module Helpers =
     open System
     open FsCheck
 
-    let sample n = Gen.sample 1000 n
+    let sample n = Gen.sampleWithSize 1000 n
 
     let sample1 gn = sample 1 gn |> List.head
     

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -137,12 +137,12 @@ module Runner =
         [<Property>]
         let ``should use configuration from enclosing module``(x:int) =
             // checking if the generated value is always the same (-59) from "01234,56789" Replay
-            x =! -84
+            x =! -4
 
         [<Property( Replay = "12345,67891")>]
         let ``should use configuration on method preferentially``(x:int) =
             // checking if the generated value is always the same (18) from "12345,67890" Replay
-            x =! 9
+            x =! -93
 
 module BugReproIssue195 =
 


### PR DESCRIPTION
Fixes #268 and fixes #236.

I actually agree that `eval` is confusing so I've removed it. 

I added extra functions in F# and overloads in C# of sample instead:
`sample` takes a desired number of values
`sampleWithSize` takes size in addition
`sampleWithSeed` takes seed in addition to make it deterministic

In C# the API is much nicer, there is just one `Sample` extension method on `Gen` with optional seed and size arguments.