### PR TITLE
Ignored Paket.Restore.targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ docs/tools/XmlWriter
 project.lock.json
 .vscode
 
+# Paket
+.paket/Paket.Restore.targets


### PR DESCRIPTION
According to
https://github.com/fsprojects/Paket/issues/2840#issuecomment-336080872
it should be ignored by Git:

> with latest paket you can gitignore it

- @forki