### PR TITLE
Fix typo. "vthe erbose" -> "the verbose"

### DIFF
--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -438,13 +438,13 @@ type Check =
     ///Check all public static methods on the given type that have a testable return type with quick configuration
     static member QuickThrowOnFailureAll<'Test>() = Check.All(Config.QuickThrowOnFailure,typeof<'Test>)
 
-    /// Check all public static methods on the given type that have a testable return type with vthe erbose configuration
+    /// Check all public static methods on the given type that have a testable return type with the verbose configuration
     static member VerboseAll test = Check.All(Config.Verbose,test)
 
-    /// Check all public static methods on the given type that have a testable return type with vthe erbose configuration
+    /// Check all public static methods on the given type that have a testable return type with the verbose configuration
     static member VerboseAll<'Test>() = Check.All(Config.Verbose,typeof<'Test>)
 
-    /// Check all public static methods on the given type that have a testable return type with vthe erbose configuration,
+    /// Check all public static methods on the given type that have a testable return type with the verbose configuration,
     ///and throws on failure or exhaustion.
     static member VerboseThrowOnFailureAll test = Check.All(Config.VerboseThrowOnFailure,test)
 


### PR DESCRIPTION
Fix typo. "vthe erbose" -> "the verbose"