### PR TITLE
remove fallback group from nupkg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       dist: trusty
       sudo: required
       mono: latest
-      dotnet: 2.0.0
+      dotnet: 2.0.3
 
 script:
   - ./build.sh RunTests

--- a/src/FsCheck.NUnit.netcore/FsCheck.NUnit.netcore.fsproj
+++ b/src/FsCheck.NUnit.netcore/FsCheck.NUnit.netcore.fsproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>FsCheck.NUnit</AssemblyName>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FsCheck.NUnit.XML</DocumentationFile>
-    <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,11 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <ProjectReference Include="../FsCheck.netcore/FsCheck.netcore.fsproj" />
     <PackageReference Include="NUnit" Version="3.8.1" />
-    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="1.0.*" />
+    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="2.*" />
   </ItemGroup>
 
 </Project>

--- a/src/FsCheck.Xunit.netcore/FsCheck.Xunit.netcore.fsproj
+++ b/src/FsCheck.Xunit.netcore/FsCheck.Xunit.netcore.fsproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>FsCheck.Xunit</AssemblyName>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FsCheck.Xunit.XML</DocumentationFile>
-    <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,12 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <ProjectReference Include="../FsCheck.netcore/FsCheck.netcore.fsproj" />
     <PackageReference Include="xunit.core" Version="2.2.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
-    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="1.0.*" />
+    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="2.*" />
   </ItemGroup>
 
 </Project>

--- a/src/FsCheck.netcore/FsCheck.netcore.fsproj
+++ b/src/FsCheck.netcore/FsCheck.netcore.fsproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>FsCheck</AssemblyName>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FsCheck.XML</DocumentationFile>
-    <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -65,9 +64,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="1.0.*" />
+    <DotNetCliToolReference Include="dotnet-mergenupkg" Version="2.*" />
   </ItemGroup>
 
 </Project>

--- a/tests/FsCheck.Test.netcore/FsCheck.Test.netcore.fsproj
+++ b/tests/FsCheck.Test.netcore/FsCheck.Test.netcore.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>FsCheck.Test</AssemblyName>
@@ -23,8 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="Unquote" Version="3.2.*" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
     <ProjectReference Include="../../src/FsCheck.Xunit.netcore/FsCheck.Xunit.netcore.fsproj" />


### PR DESCRIPTION
bump dotnet-mergenupkg to v2.2.
this remove fallback group from nupkg

cleanup for .net core sdk 2