### PR TITLE
Update PropExtensions.fs

### DIFF
--- a/src/FsCheck/PropExtensions.fs
+++ b/src/FsCheck/PropExtensions.fs
@@ -128,6 +128,27 @@ type PropertyExtensions =
 
     ///Construct a property that succeeds if both succeed. (cfr 'and')
     [<Extension>]
+    static member And(left: bool, right:Action) =
+        (PropertyExtensions.ToProperty left) .&. (PropertyExtensions.ToProperty right)
+        
+    ///Construct a property that succeeds if both succeed. (cfr 'and')
+    [<Extension>]
+    static member And(left: bool, right:bool) =
+        (PropertyExtensions.ToProperty left) .&. (PropertyExtensions.ToProperty right)
+
+
+    ///Construct a property that succeeds if both succeed. (cfr 'and')
+    [<Extension>]
+    static member And(left: bool, right:Func<bool>) =
+        (PropertyExtensions.ToProperty left) .&. (PropertyExtensions.ToProperty right)
+
+    ///Construct a property that succeeds if both succeed. (cfr 'and')
+    [<Extension>]
+    static member And(left: bool, right:Property) =
+        (PropertyExtensions.ToProperty left) .&. right
+
+    ///Construct a property that succeeds if both succeed. (cfr 'and')
+    [<Extension>]
     static member And(left: Property, right:Action) =
         left .&. (PropertyExtensions.ToProperty right)
 
@@ -145,6 +166,26 @@ type PropertyExtensions =
     [<Extension>]
     static member And(left: Property, right:Property) =
         left .&. right
+
+    ///Construct a property that fails if both fail. (cfr 'or')
+    [<Extension>]
+    static member Or(left: bool, right:Action) =
+        (PropertyExtensions.ToProperty left) .|. (PropertyExtensions.ToProperty right)
+        
+    ///Construct a property that fails if both fail. (cfr 'or')
+    [<Extension>]
+    static member Or(left: bool, right:bool) =
+        (PropertyExtensions.ToProperty left) .|. (PropertyExtensions.ToProperty right)
+
+    ///Construct a property that fails if both fail. (cfr 'or')
+    [<Extension>]
+    static member Or(left: bool, right:Func<bool>) =
+        (PropertyExtensions.ToProperty left) .|. (PropertyExtensions.ToProperty right)
+
+    ///Construct a property that fails if both fail. (cfr 'or')
+    [<Extension>]
+    static member Or(left: bool, right:Property) =
+        (PropertyExtensions.ToProperty left) .|. right
 
     ///Construct a property that fails if both fail. (cfr 'or')
     [<Extension>]


### PR DESCRIPTION
By extending the C# properties extensions on booleans, we can start combining properties directly without calling every time `ToProperty` on those booleans.