### PR TITLE
Fixes a couple of FsCheck.NUnit issues

### DIFF
--- a/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
+++ b/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
@@ -33,6 +33,10 @@ type NUnitTest() =
     member __.ReplayBroken_shouldFail (x:float) y =
         true
 
+    [<Property>]
+    member __.UnhandledException_ShouldPrint (xs : int list) =
+        Assert.IsTrue(List.length xs < 6, "this message should be visible in test explorer")
+
     // Note: should fail
     [<Property( Verbose = true )>]
     member __.RevIdVerbose_shouldFail (xs:int[]) =

--- a/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
+++ b/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
@@ -37,6 +37,14 @@ type NUnitTest() =
     member __.UnhandledException_ShouldPrint (xs : int list) =
         Assert.IsTrue(List.length xs < 6, "this message should be visible in test explorer")
 
+    [<Property; Ignore("reason")>]
+    member __.ShouldIgnore (xs : int list) =
+        false
+
+    [<Property; Category("foobar")>]
+    member __.ShouldApplyCategory (xs : int list) =
+        false
+
     // Note: should fail
     [<Property( Verbose = true )>]
     member __.RevIdVerbose_shouldFail (xs:int[]) =

--- a/src/FsCheck.NUnit/FsCheckPropertyAttribute.fs
+++ b/src/FsCheck.NUnit/FsCheckPropertyAttribute.fs
@@ -99,6 +99,7 @@ and FsCheckTestMethod(mi : IMethodInfo, parentSuite : Test) =
         TestExecutionContext.CurrentContext.CurrentResult <- testResult
         try
             try
+                use _testContext = new TestExecutionContext.IsolatedContext()
                 x.RunSetUp()
                 x.RunTestCase context testResult
             with
@@ -182,9 +183,6 @@ and FsCheckTestMethod(mi : IMethodInfo, parentSuite : Test) =
         | TestResult.Exhausted _ ->
             let msg = sprintf "Exhausted: %s" (Runner.onFinishedToString "" testRunner.Result)
             testResult.SetResult(new ResultState(TestStatus.Failed, msg), msg)
-        | TestResult.False (testdata, originalArgs, shrunkArgs, Outcome.Exception e, seed)  ->
-            let msg = sprintf "%s" (Runner.onFailureToString "" testdata originalArgs shrunkArgs seed)
-            testResult.SetResult(new ResultState(TestStatus.Failed, msg), msg)
-        | TestResult.False (testdata, originalArgs, shrunkArgs, outcome, seed) ->
+        | TestResult.False _ ->
             let msg = sprintf "%s" (Runner.onFinishedToString "" testRunner.Result)
             testResult.SetResult(new ResultState(TestStatus.Failed, msg), msg)

--- a/src/FsCheck.NUnit/FsCheckPropertyAttribute.fs
+++ b/src/FsCheck.NUnit/FsCheckPropertyAttribute.fs
@@ -82,7 +82,15 @@ type PropertyAttribute() =
 
     interface ISimpleTestBuilder with
         override __.BuildFrom(mi, suite) =
-            FsCheckTestMethod(mi, suite) :> TestMethod
+            let method = FsCheckTestMethod(mi, suite) :> TestMethod
+
+            mi.GetCustomAttributes<CategoryAttribute>(true) 
+            |> Array.iter (fun cattr -> cattr.ApplyToTest method)
+
+            mi.GetCustomAttributes<IgnoreAttribute>(true)
+            |> Array.iter (fun cattr -> cattr.ApplyToTest method)
+
+            method
 
     interface IWrapTestMethod with
         override __.Wrap command:Internal.Commands.TestCommand =


### PR DESCRIPTION
PR fixes a couple of FsCheck.NUnit issues:
* uncaught exceptions not being logged in the test results.
* isolates the test context so that assertion errors do not flood the test output during repeated shrink attempts. Ideally each individual test run should use an isolated context, however this would require modification of the core library.
* Ignoring CategoryAttribute.
* Ignoring IgnoreAttribute.