### PR TITLE
Feature/fix sublist of

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -533,8 +533,7 @@ module Gen =
     let subListOf l =
         let elems = Array.ofSeq l
         gen {// Generate indices into the array (up to the number of elements)
-             let maxNumberOfElements = if elems.Length = 1 then 1 else elems.Length-1
-             let! size = choose(0, maxNumberOfElements)
+             let! size = choose(0, elems.Length)
              let! indices = listOfLength size (choose(0, elems.Length-1)) 
              let subSeq = indices |> Seq.distinct |> Seq.map (fun i -> elems.[i])
              return List.ofSeq subSeq }

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -533,7 +533,8 @@ module Gen =
     let subListOf l =
         let elems = Array.ofSeq l
         gen {// Generate indices into the array (up to the number of elements)
-             let! size = choose(0, elems.Length-1)
+             let maxNumberOfElements = if elems.Length = 1 then 1 else elems.Length-1
+             let! size = choose(0, maxNumberOfElements)
              let! indices = listOfLength size (choose(0, elems.Length-1)) 
              let subSeq = indices |> Seq.distinct |> Seq.map (fun i -> elems.[i])
              return List.ofSeq subSeq }

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -500,3 +500,12 @@ module Gen =
     let ``generating large array should work``() =
         // occassionally there have been bugs where large array generations causes stack overflow
         Gen.choose(0,100) |> Gen.arrayOf |> Gen.sample 30000 100
+
+    [<Fact>]
+    let ``sublistof for an array with single element should generate not only empty list``() =
+        // occassionally there have been bugs where large array generations causes stack overflow
+        let d = 
+            [0..1000] 
+            |> Seq.map(fun _ -> [1] |> Gen.subListOf |> sample 1 |> List.head)
+            |> Seq.sumBy(fun x -> x |> List.sum)
+        test <@ d > 0 @>  

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -504,8 +504,8 @@ module Gen =
     [<Fact>]
     let ``sublistof for an array with single element should generate not only empty list``() =
         // occassionally there have been bugs where large array generations causes stack overflow
-        let d = 
+        let summedResults = 
             [0..1000] 
             |> Seq.map(fun _ -> [1] |> Gen.subListOf |> sample 1 |> List.head)
             |> Seq.sumBy(fun x -> x |> List.sum)
-        test <@ d > 0 @>  
+        test <@ summedResults > 0 @>  

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -503,7 +503,6 @@ module Gen =
 
     [<Fact>]
     let ``sublistof for an array with single element should generate not only empty list``() =
-        // occassionally there have been bugs where large array generations causes stack overflow
         let summedResults = 
             [0..1000] 
             |> Seq.map(fun _ -> [1] |> Gen.subListOf |> sample 1 |> List.head)

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -503,8 +503,8 @@ module Gen =
 
     [<Fact>]
     let ``sublistof for an array with single element should generate not only empty list``() =
-        let summedResults = 
-            [0..1000] 
-            |> Seq.map(fun _ -> [1] |> Gen.subListOf |> sample 1 |> List.head)
-            |> Seq.sumBy(fun x -> x |> List.sum)
-        test <@ summedResults > 0 @>  
+        let result = 
+            Gen.subListOf [1] 
+            |> Gen.sample 100 100
+            |> Seq.contains [1]
+        test <@ result @>  


### PR DESCRIPTION
I spot a problem with FsCheck when I'm using Gen.SublistOf with an argument which contains only a single element. I think in this corner scenario we should generate arrays with this single element and empty arrays. Right now only empty arrays would be generated.
I'm not 100% sure about the unit test if it suits how it should be written so any suggestion would be great!

CC: @kurtschelfthout 