### PR TITLE
FEAT: add 'NonWhiteSpaceString' to the default generated types

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -54,6 +54,11 @@ type StringNoNulls = StringNoNulls of string with
     member x.Get = match x with StringNoNulls r -> r
     override x.ToString() = x.Get
 
+// Represents a string that is not null, empty or consists only of white-space characters and does not contain any null characters ('\000')
+type NonWhiteSpaceString = NonWhiteSpaceString of string with
+    member x.Get = match x with NonWhiteSpaceString s -> s
+    override x.ToString() = x.Get
+
 ///Represents a string that can be serializable as a XML value.
 type XmlEncodedString = XmlEncodedString of string with
     member x.Get = match x with XmlEncodedString v -> v
@@ -855,6 +860,12 @@ module Arb =
             Default.String()
             |> filter (fun s -> not (String.IsNullOrEmpty s) && not (String.exists ((=) '\000') s))
             |> convert NonEmptyString string
+
+        static member NonWhiteSpaceString() =
+            Default.String()
+            |> filter (fun s -> not (String.IsNullOrWhiteSpace s) && not (String.exists ((=) '\000') s))
+            |> convert NonWhiteSpaceString string
+
 
 #if NETSTANDARD1_0 || NETSTANDARD1_6
 #else

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -144,6 +144,9 @@ module Arbitrary =
     [<Property>]
     let ``Non-empty string`` (NonEmptyString v) = not (System.String.IsNullOrEmpty v)
       
+    [<Property>]
+    let ``Non-whitespace string`` (NonWhiteSpaceString s) = not (System.String.IsNullOrWhiteSpace s)
+
 #if !NETSTANDARD1_6
     [<Property>]
     let ``XML encoded string is serializable`` (XmlEncodedString value) =


### PR DESCRIPTION
Since we also have a `String.IsNullOrWhiteSpace` and this is used quite
a lot for guard assertions and validations; it seems logical to also
generate strings without whitespace characters.

Seems reasonable?

Thanks.