### PR TITLE
Shrink DTO classes generated using reflection based generators

### DIFF
--- a/src/FsCheck/Reflect.fs
+++ b/src/FsCheck/Reflect.fs
@@ -101,6 +101,16 @@ module internal Reflect =
         let f     = l.Compile ()
         f.Invoke
 
+    let getCSharpDtoReader (recordType: Type) =
+        if isCSharpDtoType recordType then
+            let properties = getProperties recordType
+                             |> Seq.filter (fun p -> p.CanWrite)
+                             |> Seq.map (fun p -> p.GetValue)
+                             |> Seq.toArray
+            let lookup o = Array.map (fun f -> f o) properties
+            lookup
+        else
+            failwithf "The input type must be a DTO class. Got %A" recordType
 
     /// Returns the case name, type, and functions that will construct a constructor and a reader of a union type respectively
     let getUnionCases unionType : (string * (int * System.Type list * (obj[] -> obj) * (obj -> obj[]))) list = 

--- a/src/FsCheck/ReflectArbitrary.fs
+++ b/src/FsCheck/ReflectArbitrary.fs
@@ -212,6 +212,12 @@ module internal ReflectArbitrary =
             let read = FSharpValue.GetTupleFields
             shrinkChildren read make o childrenTypes
 
+        elif isCSharpDtoType t then
+            let make = getCSharpDtoConstructor t
+            let read = getCSharpDtoReader t
+            let childrenTypes = getCSharpDtoFields t
+            shrinkChildren read make o childrenTypes
+
         else
             Seq.empty
 

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -593,7 +593,7 @@ module Arbitrary =
         let shrunk = shrink value
         // check that A gets smaller (length-wise)
         shrunk
-        |> Seq.forall (fun shrunkv -> shrunkv.A.Length = 0 || shrunkv.A.Length <= value.A.Length)
+        |> Seq.forall (fun shrunkv -> shrunkv.A = null || shrunkv.A.Length = 0 || shrunkv.A.Length <= value.A.Length)
         &&
         // check that B gets smaller (in absolute value)
         shrunk

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -588,6 +588,30 @@ module Arbitrary =
     let ``Derive generator for concrete DTO class with writable properties``() =
         generate<FakeDto> |> sample 10 |> ignore
 
+    [<Property>]
+    let ``Derive generator for concrete DTO class shrinks`` (value: FakeDto) =
+        let shrunk = shrink value
+        // check that A gets smaller (length-wise)
+        shrunk
+        |> Seq.forall (fun shrunkv -> shrunkv.A.Length = 0 || shrunkv.A.Length <= value.A.Length)
+        &&
+        // check that B gets smaller (in absolute value)
+        shrunk
+        |> Seq.forall (fun shrunkv -> shrunkv.B = 0 || shrunkv.B <= abs value.B)
+        &&
+        // check that C gets smaller (in absolute value, or to null)
+        shrunk
+        |> Seq.forall (fun shrunkv ->
+                        if value.C.HasValue then
+                            (not shrunkv.C.HasValue)
+                            || shrunkv.C.Value = 0
+                            || shrunkv.C.Value <= abs value.C.Value
+                        else
+                            not shrunkv.C.HasValue)
+        &&
+        // check that D gets smaller (length-wise)
+        shrunk
+        |> Seq.forall (fun shrunkv -> shrunkv.D.Count = 0 || shrunkv.D.Count <= value.D.Count)
 
     type PrivateRecord = private { a: int; b: string }
 


### PR DESCRIPTION
When using FsCheck from C# we noticed that it didn't shrink types when we used a reflective generator. That was annoying, so here's a patch to fix it.