### PR TITLE
Always provide the own implementation of the printf operator in Runner.fs

### DIFF
--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -245,10 +245,8 @@ module Runner =
     let onShrinkToString args =
         sprintf "shrink:%s%s%s" newline (argumentsToString args) newline
 
-#if NETSTANDARD1_0
     let internal printf fmt = 
         Printf.kprintf Diagnostics.Debug.WriteLine fmt
-#endif
     
     ///A runner that prints results to the standard output.
     let consoleRunner =


### PR DESCRIPTION
I was using it for a while as unstaged change. Though appveyor and travis are happy with it as it is, compiler on my machine complains about missing printf definition when builds for .NET Standard 1.6 and 2.0. If this PR isn't acceptible, are there any thoughts about origin of this problem?   