### PR TITLE
[Sketch] Add arbitrary for System.Type

### DIFF
--- a/src/FsCheck/ArbitraryConstructor.fs
+++ b/src/FsCheck/ArbitraryConstructor.fs
@@ -6,9 +6,9 @@ open FsCheck
 
 //Is not record to easily add new params
 ///Represents constraints for generated type
-type TypeConstraints(origin : Assembly seq, 
+type TypeSpec(origin : Assembly seq, 
                      ?requiredAttributes : Type seq,
-                     ?requiredParents : Type seq) =
+                     ?requiredParents : Type seq ) =
     member __.Origin = origin
     member __.RequiredAttributes = defaultArg requiredAttributes Seq.empty
     member __.RequiredParents = defaultArg requiredParents Seq.empty
@@ -17,8 +17,8 @@ type TypeConstraints(origin : Assembly seq,
 module ArbitraryConstructor =
 
 #if NETSTANDARD2_0 || NET452 //Attribute.IsDefined is not available in lower versions, fix later 
-    let typeFrom (typeConstraints : TypeConstraints) =
-        let origin = typeConstraints.Origin
+    let typesMatchingSpec (spec : TypeSpec) =
+        let origin = spec.Origin
         let allTypes = 
             origin
             |> Seq.map (fun assembly -> assembly.GetExportedTypes() |> Seq.ofArray)
@@ -26,11 +26,13 @@ module ArbitraryConstructor =
         let withAttributes =
             let hasAttribute (t : Type) (a : Type) =
                 Attribute.IsDefined(t, a)
-            allTypes |> Seq.filter (fun t -> Seq.forall (hasAttribute t) typeConstraints.RequiredAttributes)
+            allTypes |> Seq.filter (fun t -> Seq.forall (hasAttribute t) spec.RequiredAttributes)
         let withParents =
             let isDerived (t : Type) (b : Type) =
                 b.IsAssignableFrom t
-            withAttributes |> Seq.filter (fun t -> Seq.forall (isDerived t) typeConstraints.RequiredParents)
+            withAttributes |> Seq.filter (fun t -> Seq.forall (isDerived t) spec.RequiredParents)
         withParents
+    
+    let typeGen spec = typesMatchingSpec spec |> Gen.elements
 #endif        
      

--- a/src/FsCheck/ArbitraryConstructor.fs
+++ b/src/FsCheck/ArbitraryConstructor.fs
@@ -1,0 +1,36 @@
+﻿namespace FsCheck.Experimental
+
+open System.Reflection
+open System
+open FsCheck
+
+//Is not record to easily add new params
+///Represents constraints for generated type
+type TypeConstraints(origin : Assembly seq, 
+                     ?requiredAttributes : Type seq,
+                     ?requiredParents : Type seq) =
+    member __.Origin = origin
+    member __.RequiredAttributes = defaultArg requiredAttributes Seq.empty
+    member __.RequiredParents = defaultArg requiredParents Seq.empty
+
+
+module ArbitraryConstructor =
+
+#if NETSTANDARD2_0 || NET452 //Attribute.IsDefined is not available in lower versions, fix later 
+    let typeFrom (typeConstraints : TypeConstraints) =
+        let origin = typeConstraints.Origin
+        let allTypes = 
+            origin
+            |> Seq.map (fun assembly -> assembly.GetExportedTypes() |> Seq.ofArray)
+            |> Seq.concat
+        let withAttributes =
+            let hasAttribute (t : Type) (a : Type) =
+                Attribute.IsDefined(t, a)
+            allTypes |> Seq.filter (fun t -> Seq.forall (hasAttribute t) typeConstraints.RequiredAttributes)
+        let withParents =
+            let isDerived (t : Type) (b : Type) =
+                b.IsAssignableFrom t
+            withAttributes |> Seq.filter (fun t -> Seq.forall (isDerived t) typeConstraints.RequiredParents)
+        withParents
+#endif        
+     

--- a/src/FsCheck/FsCheck.fsproj
+++ b/src/FsCheck/FsCheck.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="TypeClass.fs" />
     <Compile Include="Gen.fs" />
     <Compile Include="ReflectArbitrary.fs" />
+    <Compile Include="ArbitraryConstructor.fs" />
     <Compile Include="Arbitrary.fs" />
     <Compile Include="ArbitraryExtensions.fs" />
     <Compile Include="GenExtensions.fs" />

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -675,3 +675,7 @@ module Arbitrary =
     [<Fact>]
     let ``Derive generator for private two case union``() =
         generate<PrivateUnion> |> sample 10 |> ignore
+
+    [<Fact>]
+    let Type() =
+        generate<Type> |> sample 10 |> ignore

--- a/tests/FsCheck.Test/ArbitraryConstructor.fs
+++ b/tests/FsCheck.Test/ArbitraryConstructor.fs
@@ -8,16 +8,20 @@ module ArbitraryConstructor =
     open System
     open FsCheck.Experimental
     open FsCheck.Experimental.ArbitraryConstructor
+    
+    type SystemOriginSpec =
+        static member gen() =
+            let assembly = typeof<string>.Assembly
+            let spec = TypeSpec(assembly |> Seq.singleton)
+            spec |> typeGen |> Arb.fromGen   
 
-    [<Fact>]
-    let ``Can retrieve types``() =
-        let assembly = typeof<string>.Assembly
-        let constr = TypeConstraints(assembly |> Seq.singleton)
-        typeFrom constr |> ignore
+    [<Property(Arbitrary = [|typeof<SystemOriginSpec>|])>]
+    let ``Can retrieve types`` (t : Type) =
+        true |> Prop.collect t
     
     [<Property(MaxTest = 1)>]
     let ``Object parent equals to usnspecified parent``() =
         let assembly = typeof<string>.Assembly
-        let constrA = TypeConstraints(assembly |> Seq.singleton, requiredParents = [typeof<obj>])
-        let constrB = TypeConstraints(assembly |> Seq.singleton, requiredParents = [])
-        (typeFrom constrA |> Seq.length) = (typeFrom constrB |> Seq.length)
+        let specA = TypeSpec(assembly |> Seq.singleton, requiredParents = [typeof<obj>])
+        let specB = TypeSpec(assembly |> Seq.singleton, requiredParents = [])
+        ( specA |> typesMatchingSpec |> Seq.length) = (specB |> typesMatchingSpec |> Seq.length)

--- a/tests/FsCheck.Test/ArbitraryConstructor.fs
+++ b/tests/FsCheck.Test/ArbitraryConstructor.fs
@@ -1,0 +1,23 @@
+﻿namespace FsCheck.Experimental.Test
+
+module ArbitraryConstructor =
+
+    open Xunit
+    open FsCheck
+    open FsCheck.Xunit
+    open System
+    open FsCheck.Experimental
+    open FsCheck.Experimental.ArbitraryConstructor
+
+    [<Fact>]
+    let ``Can retrieve types``() =
+        let assembly = typeof<string>.Assembly
+        let constr = TypeConstraints(assembly |> Seq.singleton)
+        typeFrom constr |> ignore
+    
+    [<Property(MaxTest = 1)>]
+    let ``Object parent equals to usnspecified parent``() =
+        let assembly = typeof<string>.Assembly
+        let constrA = TypeConstraints(assembly |> Seq.singleton, requiredParents = [typeof<obj>])
+        let constrB = TypeConstraints(assembly |> Seq.singleton, requiredParents = [])
+        (typeFrom constrA |> Seq.length) = (typeFrom constrB |> Seq.length)

--- a/tests/FsCheck.Test/FsCheck.Test.fsproj
+++ b/tests/FsCheck.Test/FsCheck.Test.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Gen.fs" />
     <Compile Include="GenExtensions.fs" />
     <Compile Include="Arbitrary.fs" />
+    <Compile Include="ArbitraryConstructor.fs" />
     <Compile Include="Property.fs" />
     <Compile Include="Commands.fs" />
     <Compile Include="Runner.fs" />


### PR DESCRIPTION
Generator can produce non-generic types and generic types with non-generic typeparams. Shrinking is not supported yet. Sample:
```
Ok, passed 100 tests.
9% System.Text.StringBuilder.
8% System.String.
7% System.Int32.
7% System.Byte.
5% System.Enum.
5% System.Array.
4% System.Object.
3% System.Threading.Tasks.Task`1[System.Text.StringBuilder].
3% System.Threading.Tasks.Task`1[System.String].
3% System.Threading.Tasks.Task`1[System.Byte].
3% System.Collections.Generic.List`1[System.Array].
2% System.Threading.Tasks.Task`1[System.Object].
2% System.Threading.Tasks.Task`1[System.Enum].
2% System.Threading.Tasks.Task`1[System.Array].
2% System.Collections.Generic.List`1[System.Type].
2% System.Collections.Generic.List`1[System.Object].
2% System.Collections.Generic.KeyValuePair`2[System.Int32,System.Type].
2% System.Collections.Generic.Dictionary`2[System.Text.StringBuilder,System.Object].
2% System.Collections.Generic.Dictionary`2[System.Text.StringBuilder,System.Int32].
2% System.Collections.Generic.Dictionary`2[System.Enum,System.Text.StringBuilder].
1% System.Type.
```
Should we produce "nested" generic types? Thoughts about shrinker?