### PR TITLE
Minor fix in enum generator.

### DIFF
--- a/src/FsCheck/ReflectArbitrary.fs
+++ b/src/FsCheck/ReflectArbitrary.fs
@@ -17,7 +17,7 @@ module internal ReflectArbitrary =
     let enumOfType (t: System.Type) : Gen<Enum> =
        let isFlags = t.GetTypeInfo().GetCustomAttributes(typeof<System.FlagsAttribute>,false).Any() 
        let vals: Array = System.Enum.GetValues(t)
-       let elems = [ for i in 0..vals.Length-1 -> vals.GetValue(i)]     
+       let elems = [ for i in 0..vals.Length-1 -> vals.GetValue(i)] |> List.distinct  
        if isFlags then
            let elementType = System.Enum.GetUnderlyingType t
            let inline helper (elements : 'a list) =


### PR DESCRIPTION
TIL it is possible to define few enum fields with same constant undercover. Thus the enum generator was skewed and produced such constant more frequently. 

For example such property
```f#
    type MyEnum = zero = 0 | _zero = 0 | __zero = 0 | one = 1
    [<Property>]
    let _collect (e : MyEnum) =
        true |> Prop.collect e
```
produced
```
Ok, passed 100 tests.
76% _zero.
24% one.
```
and now it produces
```
Ok, passed 100 tests.
52% one.
48% _zero.
```