### PR TITLE
Use all 28 significant digits in default Decimal gen.

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -486,16 +486,26 @@ module Arb =
                 else Default.NormalFloat().Shrinker (fl |> float |> NormalFloat) |> Seq.map (fun (NormalFloat f) -> f |> float32)
             fromGenShrink (generator,shrinker)
 
-        ///Generates uniformly distributed Decimal in range [0; 1].
+        ///Generates uniformly distributed Decimal values in range [0; 1).
         static member private stdDecimalGen =
-            //Decimal format can represent every value of form [0..10^k]/(10^k) where k < 28.
-            //The bigger k we use, the more values we can possibly generate in range [0; 1].
-            //But Gen.choose returns int32, so this solution use k = 9.
-            //Enhance it!
-            let tenPow9 = 1_000_000_000
-            Gen.choose(0, tenPow9)
-            |> Gen.map Decimal
-            |> Gen.map (fun d -> d / (Decimal tenPow9))
+            gen {
+                let tenPow7 = 1_000_000_0
+                let! p1, p2, p3, p4 = 
+                    Gen.choose(0, tenPow7 - 1) 
+                    |> Gen.map bigint 
+                    |> Gen.four
+                let mant =
+                    let tenPow7 = bigint tenPow7
+                    p1 * tenPow7 * tenPow7 * tenPow7 +
+                    p2 * tenPow7 * tenPow7 +
+                    p3 * tenPow7 +
+                    p4
+                let res =
+                    let tenPow7 = decimal tenPow7
+                    let mant = decimal mant
+                    mant / tenPow7 / tenPow7 / tenPow7 / tenPow7
+                return res
+            }
 
          ///Generates arbitrary decimal between -size and size.
         static member Decimal() =

--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -488,6 +488,7 @@ module Arb =
 
         ///Generates uniformly distributed Decimal values in range [0; 1).
         static member private stdDecimalGen =
+#if !NETSTANDARD1_0
             gen {
                 let tenPow7 = 1_000_000_0
                 let! p1, p2, p3, p4 = 
@@ -506,8 +507,21 @@ module Arb =
                     mant / tenPow7 / tenPow7 / tenPow7 / tenPow7
                 return res
             }
+//.NET Standard 1.0 doesn't have explicit conversion from bigint to decimal.
+//Thus, in this case we use only 9 significant bits.
+//It isn't that trivial to implement own conversion and corefx one use
+//private fields of BigInteger.
+#else 
+            let tenPow9 = 1_000_000_000
+            Gen.choose(0, tenPow9 - 1)
+            |> Gen.map Decimal
+            |> Gen.map (fun d -> d / (Decimal tenPow9)) 
+#endif
 
-         ///Generates arbitrary decimal between -size and size.
+        ///Generates arbitrary decimal between -size and size.
+#if NETSTANDARD1_0
+        ///NOTE: .NET Standard 1.0 version use only 9 significant digits.
+#endif
         static member Decimal() =
             let generator = Gen.sized (fun size ->
                 gen {

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -519,14 +519,20 @@ module Arbitrary =
     let ``Map with string key``() =
         generate<Map<string, char>> |> sample 10 |> List.exists (fun x -> not x.IsEmpty)
 
-    [<Fact>]
-    let Decimal() =
-        generate<decimal> |> sample 10 |> ignore
+    [<Property>]
+    let Decimal (size : PositiveInt) =
+        generate<decimal> 
+        |> Gen.sample size.Get 10 
+        |> List.forall (fun d -> abs d < decimal size.Get)
 
     [<Property>]
     let ``Decimal shrinks`` (value: decimal) =
         shrink<decimal> value 
         |> Seq.forall (fun shrunkv -> shrunkv = 0m || shrunkv <= abs value)
+
+    [<Fact>]
+    let DoNotSizeDecimal() =
+        generate<DoNotSize<decimal>> |> sample 10 |> ignore
     
     [<Fact>]
     let Complex() =


### PR DESCRIPTION
Previous implementation used only 9 significant digits.