### PR TITLE
Use DoNotSize integers in default Guid gen.

### DIFF
--- a/src/FsCheck/Arbitrary.fs
+++ b/src/FsCheck/Arbitrary.fs
@@ -1058,9 +1058,9 @@ module Arb =
 
         static member Guid() =
             gen {
-                let! a = generate
-                let! b = generate
-                let! c = generate
+                let! (DoNotSize a) = generate
+                let! (DoNotSize b) = generate
+                let! (DoNotSize c) = generate
                 let! d = generate
                 let! e = generate
                 let! f = generate


### PR DESCRIPTION
Since these integers are used as bit sets, there are no reason to restrict them by size.