### PR TITLE
Add Gen.scale to avoid some boilerplate code.

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -612,6 +612,9 @@ module Gen =
     [<CompiledName("Apply")>]
     let apply (f:Gen<'a -> 'b>) (gn:Gen<'a>) : Gen<'b> = apply f gn
 
+    // Modify a size using the given function and invoke the given Gen with this size
+    let scale f g = sized (fun size -> resize (f size) g)
+    
     ///Promote the given function f to a function generator. Only used for generating arbitrary functions.
     let internal promote f = Gen (fun n r -> fun a -> let (Gen m) = f a in m n r)
 

--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -612,8 +612,10 @@ module Gen =
     [<CompiledName("Apply")>]
     let apply (f:Gen<'a -> 'b>) (gn:Gen<'a>) : Gen<'b> = apply f gn
 
-    // Modify a size using the given function and invoke the given Gen with this size
-    let scale f g = sized (fun size -> resize (f size) g)
+    ///Modify a size using the given function before passing it to the given Gen.
+    //[category: Creating generators from generators]
+    [<CompiledName("ScaleSize")>]
+    let scaleSize f g = sized (fun size -> resize (f size) g)
     
     ///Promote the given function f to a function generator. Only used for generating arbitrary functions.
     let internal promote f = Gen (fun n r -> fun a -> let (Gen m) = f a in m n r)

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -317,8 +317,8 @@ module Gen =
             && (seq { for elem in arr do yield elem :?> int} |> Seq.forall ((=) v))
     
     [<Property>]
-    let ``Scale works`` (PositiveInt size) =
-        let g = Gen.scale (fun n -> n / 10) Arb.generate<int>
+    let ``ScaleSize works`` (PositiveInt size) =
+        let g = Gen.scaleSize (fun n -> n / 10) Arb.generate<int>
         g |> Gen.sample size 100 |> List.forall (fun i -> i <= size / 10) 
 
     type MaybeNull =

--- a/tests/FsCheck.Test/Gen.fs
+++ b/tests/FsCheck.Test/Gen.fs
@@ -315,6 +315,11 @@ module Gen =
             (Array2D.length1 arr <= rows) 
             && (Array2D.length2 arr <= cols) 
             && (seq { for elem in arr do yield elem :?> int} |> Seq.forall ((=) v))
+    
+    [<Property>]
+    let ``Scale works`` (PositiveInt size) =
+        let g = Gen.scale (fun n -> n / 10) Arb.generate<int>
+        g |> Gen.sample size 100 |> List.forall (fun i -> i <= size / 10) 
 
     type MaybeNull =
         {


### PR DESCRIPTION
Inspired by the Scalacheck one.