### PR TITLE
GenExtensions: Add ScaleSize and some minor fixes 

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -321,18 +321,22 @@ module Gen =
 
     ///Combine two generators into a generator of pairs.
     //[category: Creating generators from generators]
+    [<CompiledName("Zip")>]
     let zip f g = map2 (fun x y -> x, y) f g
 
     ///Combine three generators into a generator of 3-tuples.
     //[category: Creating generators from generators]
+    [<CompiledName("Zip")>]
     let zip3 f g h = map3 (fun x y z -> x, y, z) f g h
 
     ///Split a generator of pairs into a pair of generators.
     //[category: Creating generators from generators]
+    [<CompiledName("Unzip")>]
     let unzip g = map fst g, map snd g
 
     ///Split a generator of 3-tuples into a 3-tuple of generators.
     //[category: Creating generators from generators]
+    [<CompiledName("Unzip")>]
     let unzip3 g =
         map (fun (x, _, _) -> x) g,
         map (fun (_, y, _) -> y) g,

--- a/src/FsCheck/GenExtensions.fs
+++ b/src/FsCheck/GenExtensions.fs
@@ -179,3 +179,9 @@ type GenExtensions =
     [<Extension>]
     static member OrNull (generator) =
         frequency [ (7, generator); (1, constant null) ]
+
+    ///Modify a size using the given function before passing it to the given generator.
+    //[category: Creating generators from generators]
+    [<Extension>]
+    static member ScaleSize(generator, scaleFunc) =
+        scaleSize scaleFunc generator

--- a/src/FsCheck/GenExtensions.fs
+++ b/src/FsCheck/GenExtensions.fs
@@ -178,4 +178,4 @@ type GenExtensions =
     //[category: Creating generators from generators]
     [<Extension>]
     static member OrNull (generator) =
-        oneof [ generator; constant null ]
+        frequency [ (7, generator); (1, constant null) ]

--- a/src/FsCheck/GenExtensions.fs
+++ b/src/FsCheck/GenExtensions.fs
@@ -155,20 +155,20 @@ type GenExtensions =
         if resultSelector = null then nullArg "resultSelector"
         zip generator other |> map resultSelector.Invoke
 
-    ///Combine two generators into a generator of 3-tuples.
+    ///Combine three generators into a generator of 3-tuples.
     //[category: Creating generators from generators]
     [<Extension>]
     static member Zip (generator, second, third) =
         zip3 generator second third
 
-    ///Combine two generators into a new generator of the result of the given result selector.
+    ///Combine three generators into a new generator of the result of the given result selector.
     //[category: Creating generators from generators]
     [<Extension>]
     static member Zip (generator, second, third, resultSelector : Func<_, _, _, _>) =
         if resultSelector = null then nullArg "resultSelector"
         zip3 generator second third |> map resultSelector.Invoke
 
-    ///Build a generator that generates a value from two generators  with qual probability.
+    ///Build a generator that generates a value from two generators with equal probability.
     //[category: Creating generators from generators]
     [<Extension>]
     static member Or (generator, other) =


### PR DESCRIPTION
* Add `ScaleSize` extension method.
* Replace `two` with `three` in the comments about the `Zip` of 3 extensions.
* Change the frequency of null in `OrNull` extension to 1/8 (consistent with `Gen.optionOf`).
* Add the `CompiledName` attributes to the "Zip" family of functions.

I'm not sure about the last one though. Now I realize that it may be a breaking change to the C# users.