### PR TITLE
FEAT: add C# Prop.When

### DIFF
--- a/examples/FsCheck.CSharpExamples/Program.cs
+++ b/examples/FsCheck.CSharpExamples/Program.cs
@@ -66,8 +66,11 @@ namespace FsCheck.CSharpExamples
             Prop.ForAll<int, int[]>((x, xs) => xs.Insert(x).IsOrdered().When(xs.IsOrdered()))
                 .QuickCheck("Insert");
 
-            Prop.ForAll<int>(a => new Func<bool>(() => 1 / a == 1 / a).When(a != 0))
+            Prop.ForAll<int>(a => Prop.When(a != 0, () => 1 / a == 1 / a))
                 .QuickCheck("DivByZero");
+
+            Prop.ForAll<short[]>(xs => Prop.When(condition: xs.Length > 0, assertion: () => xs.Length > 0))
+                .QuickCheck("When non-empty array ==> Assert non-empty array");
 
             //counting trivial cases
             Prop.ForAll<int, int[]>((x, xs) => 
@@ -99,6 +102,11 @@ namespace FsCheck.CSharpExamples
                     .Classify(xs.Concat(new [] { x }).IsOrdered(), "at-tail")
                     .Collect("length " + xs.Count().ToString()))
                 .QuickCheck("InsertCombined");
+
+            //inversing property outputs
+            Prop.ForAll<PositiveInt>(x => x.Get < 0)
+                .Inverse()
+                .QuickCheck("Inversed");
 
             //---labelling sub properties-----
             Prop.ForAll<int, int>((n, m) => {

--- a/examples/FsCheck.CSharpExamples/Program.cs
+++ b/examples/FsCheck.CSharpExamples/Program.cs
@@ -103,11 +103,6 @@ namespace FsCheck.CSharpExamples
                     .Collect("length " + xs.Count().ToString()))
                 .QuickCheck("InsertCombined");
 
-            //inversing property outputs
-            Prop.ForAll<PositiveInt>(x => x.Get < 0)
-                .Inverse()
-                .QuickCheck("Inversed");
-
             //---labelling sub properties-----
             Prop.ForAll<int, int>((n, m) => {
                 var res = n * m;

--- a/src/FsCheck/Prop.fs
+++ b/src/FsCheck/Prop.fs
@@ -143,6 +143,7 @@ module Prop =
     /// Turns a testable into a property that succeeds if the result of the testable is the inverse.
     [<CompiledName("Inverse"); CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
     let inverseDef (testable:Func<bool>) =
+        if testable = null then nullArg "testable"
         property (not << testable.Invoke)
 
     /// Turns a testable into a property that succeeds if the result of the testable is the inverse.

--- a/src/FsCheck/Prop.fs
+++ b/src/FsCheck/Prop.fs
@@ -147,14 +147,9 @@ module Prop =
         property (not << testable.Invoke)
 
     /// Turns a testable into a property that succeeds if the result of the testable is the inverse.
-    [<CompiledName("Inverse")>]
+    [<CompiledName("Inverse"); CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
     let inverseBool (testable:bool) =
         property (not testable)
-
-    /// Turns a testable into a property that succeeds if the result of the testable is the inverse.
-    [<CompiledName("Inverse")>]
-    let inverseFun (testable:'a -> bool) =
-        property (not << testable)
 
     /// Turns a testable into a property that succeeds if the result of the testable is the inverse. See also operator: .^. property
     [<CompiledName("Inverse")>]

--- a/src/FsCheck/Prop.fs
+++ b/src/FsCheck/Prop.fs
@@ -140,22 +140,6 @@ module Prop =
     [<CompiledName("Discard")>]
     let discard() = raise DiscardException
 
-    /// Turns a testable into a property that succeeds if the result of the testable is the inverse.
-    [<CompiledName("Inverse"); CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
-    let inverseDef (testable:Func<bool>) =
-        if testable = null then nullArg "testable"
-        property (not << testable.Invoke)
-
-    /// Turns a testable into a property that succeeds if the result of the testable is the inverse.
-    [<CompiledName("Inverse"); CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
-    let inverseBool (testable:bool) =
-        property (not testable)
-
-    /// Turns a testable into a property that succeeds if the result of the testable is the inverse. See also operator: .^. property
-    [<CompiledName("Inverse")>]
-    let inverse (testable:'Testable) =
-        ~~ (property testable |> Property.GetGen)
-
 ///Operators for Prop.
 [<AutoOpen>]
 module PropOperators =
@@ -183,7 +167,3 @@ module PropOperators =
     let (.|.) (l:'LeftTestable) (r:'RightTestable) = 
         let orProp = l .| r
         orProp
-
-    /// Turns a testable into a property that succeeds if the result of the testable is the inverse.
-    let (!!) (testable:'TestTable) =
-        Prop.inverse testable

--- a/src/FsCheck/PropExtensions.fs
+++ b/src/FsCheck/PropExtensions.fs
@@ -249,19 +249,3 @@ type PropertyExtensions =
     [<Extension>]
     static member Or(left: Property, right:Property) =
         left .|. right
-
-    ///Construct a property that succeeds if the specified condition is the inverse.
-    [<Extension>]
-    static member Inverse(condition:bool) =
-        Prop.inverseBool condition
-
-    ///Construct a property that succeeds if the specified evaluated condition is the inverse.
-    [<Extension>]
-    static member Inverse(func:Func<bool>) =
-        if func = null then nullArg "func"
-        Prop.inverse func.Invoke
-
-    ///Construct a property that succeeds if the specified evaluated condition is the inverse.
-    [<Extension>]
-    static member Inverse(property:Property) =
-        Prop.inverse property

--- a/src/FsCheck/PropExtensions.fs
+++ b/src/FsCheck/PropExtensions.fs
@@ -15,11 +15,13 @@ type PropertyExtensions =
     /// Turns a testable type into a property.
     [<Extension>]
     static member ToProperty (testable:Action) =
+        if testable = null then nullArg "testable"
         Prop.ofTestable testable.Invoke
 
     /// Turns a testable type into a property.
     [<Extension>]
     static member ToProperty (testable:Func<bool>) =
+        if testable = null then nullArg "testable"
         Prop.ofTestable testable.Invoke
     
     ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
@@ -30,21 +32,46 @@ type PropertyExtensions =
     ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
     [<Extension>]
     static member When(property:Action, condition) = 
+        if property = null then nullArg "property"
         Prop.given condition (PropertyExtensions.ToProperty property, Prop.ofTestable Res.rejected)
 
     ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
     [<Extension>]
     static member When(property:Func<bool>, condition) = 
+        if property = null then nullArg "property"
         Prop.given condition (PropertyExtensions.ToProperty property, Prop.ofTestable Res.rejected)
 
     ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
     [<Extension>]
+    static member When(property:Property, condition) = 
+        Prop.given condition (property,Prop.ofTestable Res.rejected)
+
+    ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
+    [<Extension>]
+    static member Implies(condition, property:bool) = 
+        PropertyExtensions.When(property, condition)
+
+    ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
+    [<Extension>]
+    static member Implies(condition, property:Action) = 
+        if property = null then nullArg "property"
+        PropertyExtensions.When(property, condition)
+
+    ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
+    [<Extension>]
     static member Implies(condition, property:Func<bool>) = 
+        if property = null then nullArg "property"
+        PropertyExtensions.When(property, condition)
+
+    ///Conditional property combinator. Resulting property holds if the property holds when the condition does.
+    [<Extension>]
+    static member Implies(condition, property:Property) = 
         PropertyExtensions.When(property, condition)
 
     //Classify test cases. Test cases satisfying the condition are assigned the classification given.
     [<Extension>]
     static member Classify (property: Action, cond:bool, name:string) = 
+        if property = null then nullArg "property"
         Prop.classify cond name (PropertyExtensions.ToProperty(property))
 
     ///Classify test cases. Test cases satisfying the condition are assigned the classification given.
@@ -55,16 +82,19 @@ type PropertyExtensions =
     ///Classify test cases. Test cases satisfying the condition are assigned the classification given.
     [<Extension>]
     static member Classify (property: Func<bool>, cond:bool, name:string) = 
+        if property = null then nullArg "property"
         Prop.classify cond name (PropertyExtensions.ToProperty(property))
 
     ///Classify test cases. Test cases satisfying the condition are assigned the classification given.
     [<Extension>]
     static member Classify (property: Property, cond:bool, name:string) = 
+        if name = null then nullArg "name"
         Prop.classify cond name property
 
     ///Count trivial cases. Test cases for which the condition is True are classified as trivial.
     [<Extension>]
     static member Trivial(property:Action, condition) =
+        if property = null then nullArg "property"
         Prop.trivial condition (PropertyExtensions.ToProperty(property))
 
     ///Count trivial cases. Test cases for which the condition is True are classified as trivial.
@@ -75,6 +105,7 @@ type PropertyExtensions =
     ///Count trivial cases. Test cases for which the condition is True are classified as trivial.
     [<Extension>]
     static member Trivial(property:Func<bool>, condition) =
+        if property = null then nullArg "property"
         Prop.trivial condition (PropertyExtensions.ToProperty(property))
 
     ///Count trivial cases. Test cases for which the condition is True are classified as trivial.
@@ -86,6 +117,7 @@ type PropertyExtensions =
     ///and the distribution of values is reported.
     [<Extension>]
     static member Collect (property: Action, v:'CollectedValue) = 
+        if property = null then nullArg "property"
         Prop.collect v (PropertyExtensions.ToProperty(property))
 
     ///Collect data values. The argument of collect is evaluated in each test case, 
@@ -98,6 +130,7 @@ type PropertyExtensions =
     ///and the distribution of values is reported.
     [<Extension>]
     static member Collect (property: Func<bool>, v:'CollectedValue) = 
+        if property = null then nullArg "property"
         Prop.collect v (PropertyExtensions.ToProperty(property))
 
     ///Collect data values. The argument of collect is evaluated in each test case, 
@@ -109,6 +142,7 @@ type PropertyExtensions =
     ///Add the given label to the property. The labels of a failing sub-property are displayed when it fails.
     [<Extension>]
     static member Label(property: Action, label) =
+        if property = null then nullArg "property"
         Prop.label label (PropertyExtensions.ToProperty(property))
 
     ///Add the given label to the property. The labels of a failing sub-property are displayed when it fails.
@@ -119,6 +153,7 @@ type PropertyExtensions =
     ///Add the given label to the property. The labels of a failing sub-property are displayed when it fails.
     [<Extension>]
     static member Label(property: Func<bool>, label) =
+        if property = null then nullArg "property"
         Prop.label label (PropertyExtensions.ToProperty(property))
 
     ///Add the given label to the property. The labels of a failing sub-property are displayed when it fails.
@@ -129,6 +164,7 @@ type PropertyExtensions =
     ///Construct a property that succeeds if both succeed. (cfr 'and')
     [<Extension>]
     static member And(left: bool, right:Action) =
+        if right = null then nullArg "right"
         (PropertyExtensions.ToProperty left) .&. (PropertyExtensions.ToProperty right)
         
     ///Construct a property that succeeds if both succeed. (cfr 'and')
@@ -140,6 +176,7 @@ type PropertyExtensions =
     ///Construct a property that succeeds if both succeed. (cfr 'and')
     [<Extension>]
     static member And(left: bool, right:Func<bool>) =
+        if right = null then nullArg "right"
         (PropertyExtensions.ToProperty left) .&. (PropertyExtensions.ToProperty right)
 
     ///Construct a property that succeeds if both succeed. (cfr 'and')
@@ -150,6 +187,7 @@ type PropertyExtensions =
     ///Construct a property that succeeds if both succeed. (cfr 'and')
     [<Extension>]
     static member And(left: Property, right:Action) =
+        if right = null then nullArg "right"
         left .&. (PropertyExtensions.ToProperty right)
 
     ///Construct a property that succeeds if both succeed. (cfr 'and')
@@ -160,6 +198,7 @@ type PropertyExtensions =
     ///Construct a property that succeeds if both succeed. (cfr 'and')
     [<Extension>]
     static member And(left: Property, right:Func<bool>) =
+        if right = null then nullArg "right"
         left .&. (PropertyExtensions.ToProperty right)
 
     ///Construct a property that succeeds if both succeed. (cfr 'and')
@@ -170,6 +209,7 @@ type PropertyExtensions =
     ///Construct a property that fails if both fail. (cfr 'or')
     [<Extension>]
     static member Or(left: bool, right:Action) =
+        if right = null then nullArg "right"
         (PropertyExtensions.ToProperty left) .|. (PropertyExtensions.ToProperty right)
         
     ///Construct a property that fails if both fail. (cfr 'or')
@@ -180,6 +220,7 @@ type PropertyExtensions =
     ///Construct a property that fails if both fail. (cfr 'or')
     [<Extension>]
     static member Or(left: bool, right:Func<bool>) =
+        if right = null then nullArg "right"
         (PropertyExtensions.ToProperty left) .|. (PropertyExtensions.ToProperty right)
 
     ///Construct a property that fails if both fail. (cfr 'or')
@@ -190,6 +231,7 @@ type PropertyExtensions =
     ///Construct a property that fails if both fail. (cfr 'or')
     [<Extension>]
     static member Or(left: Property, right:Action) =
+        if right = null then nullArg "right"
         left .|. (PropertyExtensions.ToProperty right)
 
     ///Construct a property that fails if both fail. (cfr 'or')
@@ -200,11 +242,26 @@ type PropertyExtensions =
     ///Construct a property that fails if both fail. (cfr 'or')
     [<Extension>]
     static member Or(left: Property, right:Func<bool>) =
+        if right = null then nullArg "right"
         left .|. (PropertyExtensions.ToProperty right)
 
     ///Construct a property that fails if both fail. (cfr 'or')
     [<Extension>]
     static member Or(left: Property, right:Property) =
         left .|. right
-        
 
+    ///Construct a property that succeeds if the specified condition is the inverse.
+    [<Extension>]
+    static member Inverse(condition:bool) =
+        Prop.inverseBool condition
+
+    ///Construct a property that succeeds if the specified evaluated condition is the inverse.
+    [<Extension>]
+    static member Inverse(func:Func<bool>) =
+        if func = null then nullArg "func"
+        Prop.inverse func.Invoke
+
+    ///Construct a property that succeeds if the specified evaluated condition is the inverse.
+    [<Extension>]
+    static member Inverse(property:Property) =
+        Prop.inverse property

--- a/src/FsCheck/Testable.fs
+++ b/src/FsCheck/Testable.fs
@@ -42,13 +42,6 @@ type Result =
         | (Outcome.True,_) -> l
         | (_,Outcome.True) -> r
         | (Outcome.Rejected,Outcome.Rejected) -> l //or r, whatever
-    static member (~~~) (p) =
-        match p.Outcome with
-        | Outcome.Exception _ -> p
-        | Outcome.Timeout _ -> p
-        | Outcome.False -> { p with Outcome = Outcome.True }
-        | Outcome.True -> { p with Outcome = Outcome.False }
-        | Outcome.Rejected -> p
 
 module internal Res =
 
@@ -179,8 +172,6 @@ module private Testable =
     let (.&) l r = combine (&&&) l r
 
     let (.|) l r = combine (|||) l r
-
-    let (~~) p = Gen.map (Rose.map (~~~)) p |> Property
 
     type Testables with
         static member Unit() =

--- a/src/FsCheck/Testable.fs
+++ b/src/FsCheck/Testable.fs
@@ -42,6 +42,13 @@ type Result =
         | (Outcome.True,_) -> l
         | (_,Outcome.True) -> r
         | (Outcome.Rejected,Outcome.Rejected) -> l //or r, whatever
+    static member (~~~) (p) =
+        match p.Outcome with
+        | Outcome.Exception _ -> p
+        | Outcome.Timeout _ -> p
+        | Outcome.False -> { p with Outcome = Outcome.True }
+        | Outcome.True -> { p with Outcome = Outcome.False }
+        | Outcome.Rejected -> p
 
 module internal Res =
 
@@ -172,6 +179,8 @@ module private Testable =
     let (.&) l r = combine (&&&) l r
 
     let (.|) l r = combine (|||) l r
+
+    let (~~) p = Gen.map (Rose.map (~~~)) p |> Property
 
     type Testables with
         static member Unit() =

--- a/tests/FsCheck.Test/Property.fs
+++ b/tests/FsCheck.Test/Property.fs
@@ -158,7 +158,12 @@ module Property =
         let a = Prop.ofTestable <| lazy failwith "crash"
         let b =  Prop.ofTestable true
         a .|. b
-            
-        
-        
+
+    [<Property>]
+    let ``not of execution should be inverse`` () =
+        !! false .&. !! (Prop.inverse true) .&. !! (fun () -> false) .&. !! (lazy false)
+
+    [<Property>]
+    let ``filter execution should reject its output`` (xs : obj array) =
+        Prop.filter (xs.Length > 0) (fun () -> xs.Length > 0)
 

--- a/tests/FsCheck.Test/Property.fs
+++ b/tests/FsCheck.Test/Property.fs
@@ -158,12 +158,3 @@ module Property =
         let a = Prop.ofTestable <| lazy failwith "crash"
         let b =  Prop.ofTestable true
         a .|. b
-
-    [<Property>]
-    let ``not of execution should be inverse`` () =
-        !! false .&. !! (Prop.inverse true) .&. !! (fun () -> false) .&. !! (lazy false)
-
-    [<Property>]
-    let ``filter execution should reject its output`` (xs : obj array) =
-        Prop.filter (xs.Length > 0) (fun () -> xs.Length > 0)
-


### PR DESCRIPTION
### More C#-friendly conditional property that holds evaluation
Before, we had to create a separate degate to specify properties that should only evalute when the condition holds. Example:

```csharp
Prop.ForAll<int>(a => new Func<bool>(() => 1 / a == 1 / a).When(a != 0))
```

With this PR we can specify it a bit more dev-friendly:
```csharp
 Prop.ForAll<int>(a => Prop.When(a != 0, () => 1 / a == 1 / a))
```