### PR TITLE
Call Dispose after Xunit test where test class inherits IDisposable

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
      "sdk": {
-        "version": "3.1.101"
+        "version": "3.1.101",
+        "rollForward": "latestMajor"
     }
 }

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -184,8 +184,16 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
         let summary = new RunSummary(Total = 1);
         let outputHelper = new TestOutputHelper()
         outputHelper.Initialize(messageBus, test)
-        let testExec() =
-            
+
+        let dispose testClass =
+            match testClass with
+            | None -> ()
+            | Some obj ->
+                match box obj with
+                | :? IDisposable as d -> d.Dispose()
+                | _ -> ()
+
+        let testExec() =            
             let config = this.Init(outputHelper)
             let timer = ExecutionTimer()
             let result =
@@ -205,6 +213,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
 
                     match xunitRunner.Result with
                           | TestResult.True _ ->
+                            dispose target
                             let output = Runner.onFinishedToString "" xunitRunner.Result
                             outputHelper.WriteLine(output)
                             new TestPassed(test, timer.Total, outputHelper.Output) :> TestResultMessage

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -211,9 +211,10 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
 
                     timer.Aggregate(fun () -> Check.Method(config, runMethod, ?target=target))
 
+                    dispose target
+
                     match xunitRunner.Result with
                           | TestResult.True _ ->
-                            dispose target
                             let output = Runner.onFinishedToString "" xunitRunner.Result
                             outputHelper.WriteLine(output)
                             new TestPassed(test, timer.Total, outputHelper.Output) :> TestResultMessage

--- a/tests/FsCheck.Test/Runner.fs
+++ b/tests/FsCheck.Test/Runner.fs
@@ -308,7 +308,7 @@ module BugReproIssue514 =
 
         [<Property>]
         member _.FakeTest (x:int) =
-            Check.One(Config.QuickThrowOnFailure, true)       
+            Check.One(Config.Quick, true)       
 
         interface IDisposable with
             member _.Dispose() = 


### PR DESCRIPTION
#514 

This pull request aims to resolve the bug uncovered in issue 514 (Dispose not called from IDisposable class when using xunit).