### PR TITLE
Allow shrinking private unions

### DIFF
--- a/src/FsCheck/ReflectArbitrary.fs
+++ b/src/FsCheck/ReflectArbitrary.fs
@@ -190,9 +190,9 @@ module internal ReflectArbitrary =
                 if Seq.isEmpty children then 0 
                 elif Seq.exists ((=) t) children then 2 
                 else 1
-            let info,_ = FSharpValue.GetUnionFields(o,t)
-            let makeCase = FSharpValue.PreComputeUnionConstructor info
-            let readCase = FSharpValue.PreComputeUnionReader info
+            let info,_ = FSharpValue.GetUnionFields(o,t,true)
+            let makeCase = FSharpValue.PreComputeUnionConstructor(info,true)
+            let readCase = FSharpValue.PreComputeUnionReader(info,true)
             let childrenTypes = info.GetFields() |> Array.map ( fun x -> x.PropertyType )
             let partitionCase t s0 (_,(_,children,make,_)) =
                 match unionSize t children with

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -692,11 +692,19 @@ module Arbitrary =
     let ``Derive generator for private two value record``() =
         generate<PrivateRecord> |> sample 10 |> ignore
 
+    [<Property>]
+    let ``Shrink for private two value record`` (DoNotShrink (value: PrivateRecord)) =
+        shrink value |> ignore
+
     type PrivateUnion = private | Case1 | Case2 of string
 
     [<Fact>]
     let ``Derive generator for private two case union``() =
         generate<PrivateUnion> |> sample 10 |> ignore
+
+    [<Property>]
+    let ``Shrink for private two case union`` (DoNotShrink (value: PrivateUnion)) =
+        shrink value |> ignore
 
     [<Fact>]
     let ``should not crash on isCSharpDto issue #545``() =


### PR DESCRIPTION
This PR allows FsCheck to shrink values of unions with private constructors, making the behavior for unions with private constructors consistent with that for records with private constructors.

FsCheck could already derive generators for records and unions with private constructors (for unions, this functionality was added in PR #186). It could also shrink values of records with a private constructor, but not values of unions with a private constructor. Several people have run into that, see issues #401, #436 and #525.

Whether automatically deriving generators and shrinkers for types with a private constructor should be done in general is something that could be discussed (this is also touched upon in issue #436), but since FsCheck already does generator derivation for such types and also does shrinker derivation for such record types, I believe being consistent for such union types is important enough to warrant this PR regardless of said discussion.
