### PR TITLE
Generate and shrink System.Collections.Immutable types reflectively.

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -26,6 +26,9 @@ group Tests
 	nuget xunit
 	nuget xunit.runner.visualstudio version_in_path: true
 	nuget Microsoft.NET.Test.Sdk
+	// don't want to have dependency on this from main package,
+	// but FsCheck can generate these reflectively, so tests need it
+	nuget System.Collections.Immutable
 
 // [ FAKE GROUP ]
 group Build

--- a/src/FsCheck.NUnit/AssemblyInfo.fs
+++ b/src/FsCheck.NUnit/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsCheck.NUnit")>]
 [<assembly: AssemblyProductAttribute("FsCheck.NUnit")>]
 [<assembly: AssemblyDescriptionAttribute("Integrates FsCheck with NUnit")>]
-[<assembly: AssemblyVersionAttribute("2.16.1")>]
-[<assembly: AssemblyFileVersionAttribute("2.16.1")>]
+[<assembly: AssemblyVersionAttribute("2.16.2")>]
+[<assembly: AssemblyFileVersionAttribute("2.16.2")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsCheck.NUnit"
     let [<Literal>] AssemblyProduct = "FsCheck.NUnit"
     let [<Literal>] AssemblyDescription = "Integrates FsCheck with NUnit"
-    let [<Literal>] AssemblyVersion = "2.16.1"
-    let [<Literal>] AssemblyFileVersion = "2.16.1"
+    let [<Literal>] AssemblyVersion = "2.16.2"
+    let [<Literal>] AssemblyFileVersion = "2.16.2"

--- a/src/FsCheck.Xunit/AssemblyInfo.fs
+++ b/src/FsCheck.Xunit/AssemblyInfo.fs
@@ -6,8 +6,8 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FsCheck.Xunit")>]
 [<assembly: AssemblyProductAttribute("FsCheck.Xunit")>]
 [<assembly: AssemblyDescriptionAttribute("Integrates FsCheck with xUnit.NET")>]
-[<assembly: AssemblyVersionAttribute("2.16.1")>]
-[<assembly: AssemblyFileVersionAttribute("2.16.1")>]
+[<assembly: AssemblyVersionAttribute("2.16.2")>]
+[<assembly: AssemblyFileVersionAttribute("2.16.2")>]
 [<assembly: InternalsVisibleToAttribute("FsCheck.Test")>]
 do ()
 
@@ -15,6 +15,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsCheck.Xunit"
     let [<Literal>] AssemblyProduct = "FsCheck.Xunit"
     let [<Literal>] AssemblyDescription = "Integrates FsCheck with xUnit.NET"
-    let [<Literal>] AssemblyVersion = "2.16.1"
-    let [<Literal>] AssemblyFileVersion = "2.16.1"
+    let [<Literal>] AssemblyVersion = "2.16.2"
+    let [<Literal>] AssemblyFileVersion = "2.16.2"
     let [<Literal>] InternalsVisibleTo = "FsCheck.Test"

--- a/src/FsCheck/AssemblyInfo.fs
+++ b/src/FsCheck/AssemblyInfo.fs
@@ -6,8 +6,8 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FsCheck")>]
 [<assembly: AssemblyProductAttribute("FsCheck")>]
 [<assembly: AssemblyDescriptionAttribute("FsCheck is a tool for testing .NET programs automatically using randomly generated test cases.")>]
-[<assembly: AssemblyVersionAttribute("2.16.1")>]
-[<assembly: AssemblyFileVersionAttribute("2.16.1")>]
+[<assembly: AssemblyVersionAttribute("2.16.2")>]
+[<assembly: AssemblyFileVersionAttribute("2.16.2")>]
 [<assembly: InternalsVisibleToAttribute("FsCheck.Test")>]
 do ()
 
@@ -15,6 +15,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsCheck"
     let [<Literal>] AssemblyProduct = "FsCheck"
     let [<Literal>] AssemblyDescription = "FsCheck is a tool for testing .NET programs automatically using randomly generated test cases."
-    let [<Literal>] AssemblyVersion = "2.16.1"
-    let [<Literal>] AssemblyFileVersion = "2.16.1"
+    let [<Literal>] AssemblyVersion = "2.16.2"
+    let [<Literal>] AssemblyFileVersion = "2.16.2"
     let [<Literal>] InternalsVisibleTo = "FsCheck.Test"

--- a/src/FsCheck/ReflectArbitrary.fs
+++ b/src/FsCheck/ReflectArbitrary.fs
@@ -52,6 +52,7 @@ module internal ReflectArbitrary =
        else 
            Gen.elements (List.map (fun (o : obj) -> o :?> Enum) elems)
 
+
     let private reflectObj getGenerator t =
 
         // is there a path via the fieldType back to the containingType?
@@ -132,6 +133,25 @@ module internal ReflectArbitrary =
             let create = getCSharpDtoConstructor t
             let g = productGen fields create
             box g
+
+        elif isImmutableCollectionType t then
+            let genericArguments = t.GetTypeInfo().GenericTypeArguments
+            if genericArguments.Length = 1 then
+                let elementType = genericArguments.[0]
+                let arrGen = elementType.MakeArrayType() |> getGenerator
+                let make = getImmutableCollection1Constructor t elementType
+                arrGen
+                |> map make
+                |> box
+            elif genericArguments.Length = 2 then
+                // Immutable(Sorted)Dictionary
+                let dictGen = typedefof<Collections.Generic.Dictionary<_,_>>.MakeGenericType(genericArguments) |> getGenerator
+                let make = getImmutableCollection2Constructor t genericArguments
+                dictGen
+                |> map make
+                |> box
+            else
+                failwithf "Unexpected System.Collections.Immutable type: %s. This is a bug in FsCheck, please open an issue." t.AssemblyQualifiedName
 
         else
             failwithf "The type %s is not handled automatically by FsCheck. Consider using another type or writing and registering a generator for it." t.FullName
@@ -230,6 +250,35 @@ module internal ReflectArbitrary =
             let read = getCSharpDtoReader t
             let childrenTypes = getCSharpDtoFields t
             shrinkChildren read make o childrenTypes
+            
+        elif isImmutableCollectionType t then
+            let genericArguments = t.GetTypeInfo().GenericTypeArguments
+            if genericArguments.Length = 1 then
+                let elementType = genericArguments.[0]
+                let shrinkAsArray =
+                    elementType.MakeArrayType()
+                    |> getShrink
+                let read = getImmutableCollection1Reader elementType
+                let make = getImmutableCollection1Constructor t elementType
+                o
+                |> read
+                |> shrinkAsArray
+                |> Seq.map make
+            elif genericArguments.Length = 2 then
+                // Immutable(Sorted)Dictionary
+                let keyType, valueType = genericArguments.[0], genericArguments.[1]
+                let elementType = typedefof<Collections.Generic.KeyValuePair<_,_>>.MakeGenericType(keyType, valueType)
+                let shrinkAsArray =
+                    typedefof<Collections.Generic.KeyValuePair<_,_>>.MakeGenericType(keyType, valueType)
+                    |> getShrink
+                let read = getImmutableCollection1Reader elementType
+                let make = getImmutableCollection2Constructor t genericArguments
+                o
+                |> read
+                |> shrinkAsArray
+                |> Seq.map make
+            else
+                failwithf "Unexpected System.Collections.Immutable type: %s. This is a bug in FsCheck, please open an issue." t.AssemblyQualifiedName
 
         elif t.GetTypeInfo().IsEnum then
             let isFlags = t.GetTypeInfo().GetCustomAttributes(typeof<System.FlagsAttribute>,false).Any() 

--- a/tests/FsCheck.Test/paket.references
+++ b/tests/FsCheck.Test/paket.references
@@ -6,3 +6,4 @@ group Tests
 	FSharp.Core
 	Unquote
 	Microsoft.NET.Test.Sdk
+	System.Collections.Immutable


### PR DESCRIPTION
Closes #574 

This was done via reflection to avoid having to take a dependency on another package in FsCheck. The types in System.Collections.Immutable are very regular so this wasn't such a big issue.