### PR TITLE
Add FsCheck.Xunit.TestOutputRunner.

### DIFF
--- a/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
+++ b/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Runner.fs" />
     <Compile Include="PropertyAttribute.fs" />
     <Compile Include="CheckExtensions.fs" />
   </ItemGroup>

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -3,10 +3,11 @@
 open System
 open System.Threading.Tasks
 
-open FsCheck
 open Xunit
 open Xunit.Sdk
 open Xunit.Abstractions
+
+open FsCheck
 
 type PropertyFailedException =
     inherit Exception

--- a/src/FsCheck.Xunit/Runner.fs
+++ b/src/FsCheck.Xunit/Runner.fs
@@ -1,0 +1,20 @@
+﻿namespace FsCheck.Xunit
+
+open FsCheck
+   
+/// A runner for FsCheck (i.e. that you can use as Config.Runner) which outputs
+/// to Xunit's given ITestOutputHelper.
+/// For example, { Config.QuickThrowOnFailure with Runner = TestOutputRunner(output) }
+type TestOutputRunner(output: Xunit.Abstractions.ITestOutputHelper) =
+    interface IRunner with
+        member _.OnStartFixture t =
+            output.WriteLine (Runner.onStartFixtureToString t)
+        member _.OnArguments (ntest, args, every) =
+            output.WriteLine (every ntest args)
+        member _.OnShrink(args, everyShrink) =
+            output.WriteLine (everyShrink args)
+        member _.OnFinished(name,testResult) =
+            let resultText = Runner.onFinishedToString name testResult
+            match testResult with
+            | TestResult.True _ -> resultText |> output.WriteLine
+            | _ -> failwithf "%s" resultText


### PR DESCRIPTION
Closes #509 

@breki what do you know, I finally got to this. From your example:
- I removed the `verbose` flag because that ought to be controlled via the `Config` by setting `Every` and `EveryShrink` and so I felt it was redundant
- Made it into a proper type so it's easier to access for C# users, and also you can now inherit it and call the relevant `super` methods to do the default thing if you want (like e.g. bringing `verbose` back....)

Let me know if you have any thoughts.