### PR TITLE
Fix for type inference/release build issue in 2.16.1

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -117,16 +117,7 @@ Target.create "Build" (fun _ ->
 
 Target.create "RunTests" (fun _ ->
   "tests/FsCheck.Test/"
-  |> DotNet.test (fun opt -> opt)
-    // !! testAssemblies
-    // |> XUnit2.run (fun p ->
-    //         { p with
-    //             //ToolPath = "packages/build/xunit.runner.console/tools/xunit.console.exe"
-    //             //The NoAppDomain setting requires care.
-    //             //On mono, it needs to be true otherwise xunit won't work due to a Mono bug.
-    //             //On .NET, it needs to be false otherwise Unquote won't work because it won't be able to load the FsCheck assembly.
-    //             NoAppDomain = Environment.isMono
-    //             ShadowCopy = false })
+  |> DotNet.test (fun opt -> { opt with Configuration = DotNet.BuildConfiguration.Release })
 )
 
 // --------------------------------------------------------------------------------------

--- a/src/FsCheck/ReflectArbitrary.fs
+++ b/src/FsCheck/ReflectArbitrary.fs
@@ -191,7 +191,7 @@ module internal ReflectArbitrary =
         else
             fun _ -> []
 
-    let private reflectShrinkObj getShrink o (t:Type) = 
+    let private reflectShrinkObj (getShrink:Type->obj->seq<obj>) o (t:Type) = 
         //assumes that l contains at least one element. 
         let split3 l =
             let rec split3' front m back =
@@ -311,4 +311,4 @@ module internal ReflectArbitrary =
         else
             Seq.empty
 
-    let reflectShrink getShrink (a:'a) = reflectShrinkObj getShrink a (typeof<'a>) |> Seq.map (unbox<'a>)
+    let reflectShrink<'T> (getShrink: Type -> obj -> seq<obj>) (a:'T) = reflectShrinkObj getShrink a (typeof<'T>) |> Seq.map (unbox<'T>)

--- a/src/FsCheck/TypeClass.fs
+++ b/src/FsCheck/TypeClass.fs
@@ -51,11 +51,11 @@ module TypeClass =
                     Array <| arr
             | prim -> Primitive prim
  
-    let private getMethods (t: Type) =
+    let private getMethods (t: Type) : seq<MethodInfo> =
         #if NETSTANDARD1_0
         t.GetRuntimeMethods()
         #else
-        t.GetMethods(BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.FlattenHierarchy ||| BindingFlags.NonPublic ||| BindingFlags.Instance)
+        upcast t.GetMethods(BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.FlattenHierarchy ||| BindingFlags.NonPublic ||| BindingFlags.Instance)
         #endif
     
     //returns a dictionary of generic types to methodinfo, a catch all, and array types in a list by rank


### PR DESCRIPTION
Closes #587 

A story about the dangers of type inference and/or release builds.

The problem in the referenced issue only occurs release builds, so also testing release builds by default now, as that is what we're shipping.