### PR TITLE
Merge PropertiesAttribute through nested types/modules

### DIFF
--- a/FsCheck Release Notes.md
+++ b/FsCheck Release Notes.md
@@ -1,6 +1,6 @@
 ### 2.16.3 - To be released
 
-
+* Allow configuration in FsCheck.Xunit.PropertiesAttribute to affect properties on nested types or modules. PropertiesAttribute on the closest enclosing type takes precedence.
 
 ### 2.16.2 - 30 August 2021
 

--- a/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
+++ b/src/FsCheck.Xunit/FsCheck.Xunit.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>FsCheck.Xunit</AssemblyName>
-    <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard1.6</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>


### PR DESCRIPTION
Closes #394 

Pretty easy change given we already had hierarchical merging of configuration through Properties/PropertyAttribute through Assembly -> Class -> Method level. At that point skipping any intermediate modules or types just seemed counter-intuitive.