### PR TITLE
Add prop rejection helpers

### DIFF
--- a/src/FsCheck/FSharp.Prop.fs
+++ b/src/FsCheck/FSharp.Prop.fs
@@ -77,6 +77,14 @@ module Prop =
     [<CompiledName("Discard")>]
     let discard() = raise DiscardException
 
+    /// A rejected property
+    [<CompiledName("Rejected")>]
+    let rejected = Prop.ofBool false
+    
+    /// Reject a property with a specific message
+    [<CompiledName("RejectWith")>]
+    let rejectWith message = rejected |> label message
+
 ///Operators for Prop.
 [<AutoOpen>]
 module PropOperators =


### PR DESCRIPTION
I sometimes find myself wanting to reject a property, but not being able to just return `false`, because my test returns a `Property`, such as in this case:
```fsharp
match parse s with
| Some value -> value = original |@ "Parsed incorrect value"
| None -> false // Cannot return false, since the other branch returns a Property
```
In this case I would do
```fsharp
| None -> Prop.rejectWith "Could not parse"
```