### PR TITLE
+ Map overload to make it F#+ friendly

### DIFF
--- a/src/FsCheck/Gen.fs
+++ b/src/FsCheck/Gen.fs
@@ -649,8 +649,11 @@ type Gen<'a> with
     /// Lifted function application = apply f to a, all in the Gen applicative functor.
     static member (<*>) (f, a) = apply f a
 
-    /// Like <*>, but puts f in a Gen first.
+    /// Like <*>, but puts f in a Gen first. An alias for Map.
     static member (<!>) (f, a) = Gen.constant f <*> a
+    
+    /// Like <*>, but puts f in a Gen first.
+    static member Map (f, a) = Gen.constant f <*> a
 
     /// Bind operator; runs the first generator, then feeds the result
     /// to the second generator function.


### PR DESCRIPTION
I propose to add this overload to make it F#+ friendly.

F#+ (as many other libs) defines also `<!>`, `<*>` and `>>=`, but in a generic way and actually it doesn't cause any problem with `<*>` and `>>=`, but for `<!>` it expects a `Map` static member.

This is a small adjustment, backwards compatible and it doesn't cause any problem here.

Eventually if you don't agree to expose a `Map` static member, I can hide it with `[<EditorBrowsable(EditorBrowsableState.Never)>]`