### PR TITLE
Enable properties that return Task<'a>

### DIFF
--- a/src/FsCheck/Testable.fs
+++ b/src/FsCheck/Testable.fs
@@ -200,6 +200,9 @@ module private Testable =
         static member Task() =
             { new ITestable<Task> with
                 member __.Property b = Prop.ofTask b }
+        static member TaskGeneric() =
+            { new ITestable<Task<'T>> with
+                member __.Property b = Prop.ofTask (b :> Task) }
         static member AsyncBool() =
             { new ITestable<Async<bool>> with
                 member __.Property b = Prop.ofTaskBool <| Async.StartAsTask b }

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -783,3 +783,8 @@ module Arbitrary =
 
         assert (ImmutableDictionary.CreateRange(values) |> shrink |> Seq.forall checkShrink)
         assert (ImmutableSortedDictionary.CreateRange(values) |> shrink |> Seq.forall checkShrink)
+
+    [<Property>]
+    let ``should execute generic-task-valued property`` (value: int) =
+        // Since this doesn't throw, the test should pass and ignore the integer value
+        System.Threading.Tasks.Task.FromResult value

--- a/tests/FsCheck.Test/Property.fs
+++ b/tests/FsCheck.Test/Property.fs
@@ -179,7 +179,19 @@ module Property =
                 | TestResult.Passed _  -> true
                 | TestResult.Failed _ -> false
                 | TestResult.Exhausted _ -> false @>
-    
+
+    [<Fact>]
+    let ``Generic task-asynchronous tests should be passable``() =
+        let resultRunner = GetResultRunner()
+        let config = Config.Quick.WithRunner(resultRunner).WithMaxTest(1)
+        let tcs = TaskCompletionSource<unit>()
+        tcs.SetResult(())
+        Check.One (config, Prop.ofTestable tcs.Task) // No upcast
+        test <@ match resultRunner.Result with
+                | TestResult.Passed _  -> true
+                | TestResult.Failed _ -> false
+                | TestResult.Exhausted _ -> false @>
+
     [<Fact>]
     let ``Task-asynchronous tests should be failable by raising an exception``() =
         let resultRunner = GetResultRunner()


### PR DESCRIPTION
This is intended to address #633.

I'm a little concerned whether the addition of `TaskGeneric` overrides or shadows the more specific `TaskBool`, but all tests pass. Still, I wanted to call attention to this question, since I don't have complete understanding of how the underlying machinery works.