### PR TITLE
Generates negative decimal values

### DIFF
--- a/src/FsCheck/Internals.DefaultArbs.fs
+++ b/src/FsCheck/Internals.DefaultArbs.fs
@@ -208,8 +208,13 @@ type internal Default private() =
                 |> Gen.map Decimal
                 |> Gen.map (fun d -> d / (Decimal tenPow9)) 
             let generator = Gen.sized (fun size ->
-                decimalGen
-                |> Gen.map (fun d -> d * Decimal(size)))
+                Gen.map2
+                    (fun d isNegative -> 
+                        let value = d * Decimal(size)
+                        if isNegative then -value else value)
+                    decimalGen
+                    Default.Bool.Generator
+                )
             let shrinker d =
                 let (|<|) x y = abs x < abs y
                 seq {

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -560,6 +560,15 @@ module Arbitrary =
         |> Seq.forall (fun shrunkv -> shrunkv = 0m || shrunkv <= abs value)
         |> assertTrue
 
+    [<Property>]
+    let ``Negative decimal values are generated`` (size : PositiveInt) =
+        let predicate = fun (d: decimal) -> d < 0m
+        generate<decimal>
+        |> Gen.filter predicate
+        |> Gen.sampleWithSize size.Get 10
+        |> Array.forall predicate
+        |> assertTrue
+
     [<Fact>]
     let DoNotSizeDecimal() =
         generate<DoNotSize<decimal>> |> sample 10 |> ignore


### PR DESCRIPTION
Heya! When writing some tests with FsCheck yesterday, I discovered the tests taking forever because `Gen.filter (fun d -> d <= 0)` for decimals was never satisfying the predicate.

I copied how negative values are created for `NormalFloat`.

I added a test that uses the above filter to make sure negative values are generated. If there's a regression that reverts back to previous behavior (i.e. only generating positive decimals), this test will "fail" by hitting a timeout in CI. Is that okay?

Thank you for the great library, and have a great weekend!