### PR TITLE
Fix package icons

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,14 @@
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <DebugType>embedded</DebugType>
-    <PackageIconUrl>https://raw.githubusercontent.com/fscheck/FsCheck/master/docs/files/img/logo.png</PackageIconUrl>
+    <PackageIcon>logo.png</PackageIcon>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>test;testing;random;fscheck;quickcheck</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../../docs/img/logo.png">
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <PackageTags>test;testing;random;fscheck;quickcheck</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../../docs/img/logo.png">
+    <None Include="../../docs/img/logo.png" Condition="'$(IsPackable)' == 'true'" >
       <Pack>true</Pack>
       <PackagePath>\</PackagePath>
     </None>


### PR DESCRIPTION
ref: #663 

This is a bit brittle in that it depends on every NuGet package living directly under `src/{packagename}`; the `None Include` will be wrong for other packages. Tell me to stamp it out in the individual projects if you prefer.
<img width="1656" alt="Screenshot 2024-02-25 at 14 28 12" src="https://github.com/fscheck/FsCheck/assets/3138005/7250fb93-73c5-44f2-96fd-9b9e1aa5f6de">

