### PR TITLE
Run dotnet pack in CI too

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -646,7 +646,7 @@ Target.create "Release" (fun _ ->
 )
 *)
 
-let runCi (_ : HaveGeneratedDocs) (_ : HaveTested) =
+let runCi (_ : HaveGeneratedDocs) (_ : HaveTested) (_ : HavePacked) =
     // this is just a target to note that we have done all the above
     ()
 
@@ -666,7 +666,8 @@ match args |> List.map (fun s -> s.ToLowerInvariant ()) with
     let haveBuilt = build haveCleaned haveGeneratedAssemblyInfo
     let haveTested = runDotnetTest haveCleaned
     let haveGeneratedDocs = docs haveBuilt
-    runCi haveGeneratedDocs haveTested
+    let havePacked = packNuGet haveTested
+    runCi haveGeneratedDocs haveTested havePacked
 | ["-t" ; "ghrelease"] ->
     let haveCleaned = doClean ()
     let haveGeneratedAssemblyInfo = generateAssemblyInfo haveCleaned


### PR DESCRIPTION
ref: #663 

Seems reasonable to fail CI if we can't create the NuGet package locally.

This has some interaction I don't understand with AppVeyor, which has uploaded artefacts… somewhere. I hope I haven't somehow blatted prod, but this way the nupkgs are available at https://ci.appveyor.com/project/kurtschelfthout/fscheck/builds/49266158/artifacts (for example).
```
Collecting artifacts...
Found artifact 'bin\FsCheck.3.0.0-rc2.nupkg' matching 'bin\*.nupkg' path
Found artifact 'bin\FsCheck.NUnit.3.0.0-rc2.nupkg' matching 'bin\*.nupkg' path
Found artifact 'bin\FsCheck.Xunit.3.0.0-rc2.nupkg' matching 'bin\*.nupkg' path
Uploading artifacts...
[1/3] bin\FsCheck.3.0.0-rc2.nupkg (379,992 bytes)...100%
[2/3] bin\FsCheck.NUnit.3.0.0-rc2.nupkg (15,610 bytes)...100%
[3/3] bin\FsCheck.Xunit.3.0.0-rc2.nupkg (27,565 bytes)...100%
```