### PR TITLE
Stop printing stdout when we're in Watch mode

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -41,12 +41,17 @@ module Utils =
             let lastStdout =
                 lock stdout (fun () -> if stdout.Count = 0 then None else Some stdout.[stdout.Count - 1])
                 |> Option.defaultValue "<no output yet>"
-            Console.WriteLine $"Last stdout: %s{lastStdout}"
-            let lastStderr =
-                lock stderr (fun () -> if stderr.Count = 0 then None else Some stderr.[stderr.Count - 1])
-                |> Option.defaultValue "<no error output yet>"
-            Console.WriteLine $"Last stderr: %s{lastStderr}"
-            return! go ()
+            if lastStdout.Contains ("listener started", StringComparison.OrdinalIgnoreCase) then
+                // `fsdocs watch` will sit there until it's quit, so we just stop watching in that case
+                Console.WriteLine $"\n%s{lastStdout}"
+                return ()
+            else
+                Console.WriteLine $"Last stdout: %s{lastStdout}"
+                let lastStderr =
+                    lock stderr (fun () -> if stderr.Count = 0 then None else Some stderr.[stderr.Count - 1])
+                    |> Option.defaultValue "<no error output yet>"
+                Console.WriteLine $"Last stderr: %s{lastStderr}"
+                return! go ()
         }
         let cts = new CancellationTokenSource ()
 


### PR DESCRIPTION
Output now looks like:
```
FsCheck git:(master) > dotnet fsi build.fsx -t WatchDocs
Running fsdocs watch... (started process 68701) Last stdout:   generating model for docs/QuickStart.fsx --> ./QuickStart.html
Last stderr: <no error output yet>

Press any key to continue ...[14:41:46 INF] Smooth! Suave listener started in 25.6ms with binding 127.0.0.1:8901
```