### PR TITLE
Deterministic builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
+    <Deterministic>true</Deterministic>
     <Copyright>Copyright 2008-2024</Copyright>
     <Authors>Kurt Schelfthout and contributors</Authors>
     <PackageTags>F# fsharp test random</PackageTags>
@@ -20,5 +21,8 @@
       <Pack>true</Pack>
       <PackagePath>\</PackagePath>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(APPVEYOR_BUILD_VERSION)' != ''">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
   <PropertyGroup>
     <Deterministic>true</Deterministic>
     <Copyright>Copyright 2008-2024</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,5 +38,6 @@
     <PackageVersion Include="xunit.extensibility.core" Version="[2.4.1, 3.0.0)" />
     <PackageVersion Include="xunit.extensibility.execution" Version="[2.4.1, 3.0.0)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,5 @@
     <PackageVersion Include="xunit.extensibility.core" Version="[2.4.1, 3.0.0)" />
     <PackageVersion Include="xunit.extensibility.execution" Version="[2.4.1, 3.0.0)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Ref: #664

Works for me in the sense that the resulting nupkg lets me "go to definition" in Rider and I see the F# source. I'll do the same check with the nupkgs that AppVeyor gives me, just to make sure.