### PR TITLE
Bugfix FsCheck.Fluent.Gen.Fresh

### DIFF
--- a/src/FsCheck/Fluent.Gen.fs
+++ b/src/FsCheck/Fluent.Gen.fs
@@ -20,7 +20,7 @@ type Gen =
     /// objects.
     /// See also constant.
     //[category: Creating generators]
-    static member Fresh(create:Func<Gen<'T>>) = 
+    static member Fresh(create:Func<'T>) = 
         if isNull create then nullArg "create"
         Gen.fresh create.Invoke
 


### PR DESCRIPTION
I might be missing something, but it seems to me like the `create` parameter of `FsCheck.Fluent.Gen.Fresh` has the wrong type. It should be `Func<'T>` (not `Func<Gen<'T>>`).

For comparison, the `create` parameter of `FsCheck.FSharp.Gen.fresh` is of type `unit -> 'T`.