### PR TITLE
NUnit4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,9 @@ project.lock.json
 .fsdocs/
 output/
 tmp/
+
+#######
+# Rider
+#######
+.idea/
+

--- a/Contributors.txt
+++ b/Contributors.txt
@@ -1,4 +1,4 @@
-First of all credit should go to John Hughes and Koen Claessen for coming up with the fist version of Haskell's QuickCheck and many fundanmental improvements and ideas. All contributors to QuickCheck are contributors to FsCheck.
+First of all credit should go to John Hughes and Koen Claessen for coming up with the fist version of Haskell's QuickCheck and many fundamental improvements and ideas. All contributors to QuickCheck are contributors to FsCheck.
 
 The same is true, but to a lesser degree, for scalacheck (which is itself a port of QuickCheck to Scala).
 
@@ -14,6 +14,7 @@ David Crocker (first version of replay mechanism, bug fix)
 Howard Mansell (lots of generators and arbitrary instances)
 David Jones (tail recursive version of Gen.sequence, bug fixes)
 Matthew Peacock (gen workflow extensions)
+David Naylor (NUnit 4, sponsored by Counterpoint Dynamics)
 (my sincerest apologies to anyone I overlooked - feel free to protest!)
 
 Thanks to:

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -15,7 +15,7 @@ nuget Microsoft.NET.Test.Sdk
 nuget xunit
 nuget xunit.runner.visualstudio
 
-nuget NUnit
+nuget NUnit >= 3.13.1 < 5
 nuget NUnit3TestAdapter
 
 nuget MSTest.TestFramework

--- a/src/FsCheck.NUnit/paket.template
+++ b/src/FsCheck.NUnit/paket.template
@@ -14,7 +14,7 @@ licenseUrl
 requireLicenseAcceptance
     false
 copyright
-    Copyright 2017
+    Copyright 2024
 tags
     test testing random fscheck quickcheck nunit
 summary
@@ -25,7 +25,7 @@ description
     All the options normally available in vanilla FsCheck via configuration can be controlled via the PropertyAttribute.
 dependencies
     FsCheck = CURRENTVERSION
-    NUnit ~> 3.10 >= 3.13.1
+    NUnit >= 3.13.1 < 5
 files
 	bin/Release/netstandard2.0/FsCheck.NUnit.dll ==> lib/netstandard2.0
     bin/Release/netstandard2.0/FsCheck.NUnit.xml ==> lib/netstandard2.0


### PR DESCRIPTION
This pull request extends the dependency requirement for FsCheck.NUnit to also include NUnit 4.  

I've taken a stab at updating FsCheck to NUnit 4 (`dotnet paket update nunit`).  The one issue is NUnit 4 no longer supports `netstandard2.0`, but instead targets `net6` (and it seems Paket/FsCheck does not support targeting .NET Framework).  Other than that there were no changes needed (i.e. no changes to `FsCheckPropertyAttribute.fs`).  

As others have reported, and I can confirm, just forcing FsCheck.NUnit v2 to use NUnit 4 works.  

I thought this approach was the most versatile (and does not break backward compatibility).  

Fixes #650.  

Sponsored by [Counterpoint Dynamics](https://cpdynamics.co.za).