### PR TITLE
Handle NUnit ResultStateException. Fixes #627

### DIFF
--- a/examples/FsCheck.NUnit.CSharpExamples/Examples.cs
+++ b/examples/FsCheck.NUnit.CSharpExamples/Examples.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using FsCheck.Fluent;
 using NUnit.Framework;
 
@@ -27,6 +28,29 @@ namespace FsCheck.NUnit.CSharpExamples
         public bool Replay(int x)
         {
             return Int32.MaxValue >= x;
+        }
+
+        /// <summary> Example for using Assert.Pass; Note: should pass </summary>
+        [Property]
+        public async Task AssertPass_shouldPass()
+        {
+            await Task.Yield();
+
+            Assert.Pass("this test is successful");
+        }
+
+        /// <summary> Example for using Assert.Ignore; Note: test should be marked as Skipped in results </summary>
+        [Property]
+        public void AssertIgnore_should_be_Skipped()
+        {
+            Assert.Ignore("ignore this test");
+        }
+
+        /// <summary> Example for using Assert.Inconclusive; Note: test should be marked as Not Run in results </summary>
+        [Property]
+        public void AssertInconclusive_should_be_NotRun()
+        {
+            Assert.Inconclusive("this test is inconclusive");
         }
     }
 }

--- a/tests/FsCheck.Test/FsCheck.NUnit/PropertyAttributeTests.fs
+++ b/tests/FsCheck.Test/FsCheck.NUnit/PropertyAttributeTests.fs
@@ -1,0 +1,16 @@
+﻿namespace Fscheck.Test.FsCheck.NUnit.PropertyAttribute
+
+open FsCheck
+open FsCheck.NUnit
+
+module ResultStateExceptionHandlingTest =
+    [<Property>]
+    let ``should pass when AssertPass called``() =
+        NUnit.Framework.Assert.Pass()
+
+    [<Property>]
+    let ``should pass when AssertPass called inside async``() =
+        async {
+            NUnit.Framework.Assert.Pass()
+        }
+

--- a/tests/FsCheck.Test/FsCheck.Test.fsproj
+++ b/tests/FsCheck.Test/FsCheck.Test.fsproj
@@ -10,6 +10,7 @@
         <DefineConstants>DEBUG</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
+        <Compile Include="FsCheck.NUnit\PropertyAttributeTests.fs" />
         <Compile Include="Fscheck.XUnit\PropertyAttributeTests.fs" />
         <Compile Include="Helpers.fs" />
         <Compile Include="Random.fs" />
@@ -26,6 +27,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/FsCheck.Xunit/FsCheck.Xunit.fsproj" />
+        <ProjectReference Include="../../src/FsCheck.NUnit/FsCheck.NUnit.fsproj" />
         <ProjectReference Include="..\FsCheck.Test.CSharp\FsCheck.Test.CSharp.csproj" />
     </ItemGroup>
     <ItemGroup>
@@ -38,5 +40,6 @@
         <PackageReference Include="Unquote" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="System.Collections.Immutable" />
+        <PackageReference Include="NUnit3TestAdapter" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Hello,

could you please review this PR. This should fix bug #627 and now 
NUnit integration should not fail test when "Assert.Ignore" or "Assert.Pass" are called,
this includes "async"-tests.

Test results after the fix look like this:
![image](https://github.com/user-attachments/assets/3e1f6a48-8afe-46af-9497-2bfa7c1c0af8)
 