### PR TITLE
Fix stamps missing from final test

### DIFF
--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -429,7 +429,7 @@ module Runner =
             else 
                 test size.IsSome
         testSeq (float <| defaultArg size config.StartSize) ((+) increaseSizeStep) seed (property prop |> Property.GetGen config.ArbMap)
-        |> Seq.takeWhile (fun step ->
+        |> Common.takeWhilePlusLast (fun step ->
             match step with
                 | Run (result,s,seed) ->
                     lastStep := step

--- a/tests/FsCheck.Test/Property.fs
+++ b/tests/FsCheck.Test/Property.fs
@@ -169,6 +169,16 @@ module Property =
         a .|. b
 
     [<Fact>]
+    let ``Single test with stamp should have the stamp in output``() =
+        let resultRunner = GetResultRunner()
+        let config = Config.Quick.WithRunner(resultRunner).WithMaxTest(1)
+        Check.One (config, true |> Prop.trivial true)
+        test <@ match resultRunner.Result with
+                | TestResult.Passed (d, _) -> Seq.toList d.Stamps = [ 100, ["trivial"] ]
+                | TestResult.Failed _ -> false
+                | TestResult.Exhausted _ -> false @>
+
+    [<Fact>]
     let ``Task-asynchronous tests should be passable``() =
         let resultRunner = GetResultRunner()
         let config = Config.Quick.WithRunner(resultRunner).WithMaxTest(1)


### PR DESCRIPTION
I believe this is a regression from https://github.com/fscheck/FsCheck/pull/284, original issue #283, where the last run of a property is missing classifications

Should be possible to reproduce by running a property with maxTests of 1, add `trivial` stamp, quietOnSuccess=false and the stamp won't be shown. With maxTests of 2 it will show 50% trivial, with 3 it will show 66% trivial, etc