### PR TITLE
NUnit4

### DIFF
--- a/Contributors.txt
+++ b/Contributors.txt
@@ -1,4 +1,4 @@
-First of all credit should go to John Hughes and Koen Claessen for coming up with the fist version of Haskell's QuickCheck and many fundanmental improvements and ideas. All contributors to QuickCheck are contributors to FsCheck.
+First of all credit should go to John Hughes and Koen Claessen for coming up with the fist version of Haskell's QuickCheck and many fundamental improvements and ideas. All contributors to QuickCheck are contributors to FsCheck.
 
 The same is true, but to a lesser degree, for scalacheck (which is itself a port of QuickCheck to Scala).
 
@@ -14,6 +14,7 @@ David Crocker (first version of replay mechanism, bug fix)
 Howard Mansell (lots of generators and arbitrary instances)
 David Jones (tail recursive version of Gen.sequence, bug fixes)
 Matthew Peacock (gen workflow extensions)
+David Naylor (NUnit 4, sponsored by Counterpoint Dynamics)
 (my sincerest apologies to anyone I overlooked - feel free to protest!)
 
 Thanks to:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NuGet.Frameworks" Version="5.11" />
-    <PackageVersion Include="NUnit" Version="[3.13.1,4.0.0)" />
+    <PackageVersion Include="NUnit" Version="[3.13.1,5.0.0)" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.0" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Collections" Version="4.3" />

--- a/FsCheck.sln
+++ b/FsCheck.sln
@@ -4,17 +4,18 @@ VisualStudioVersion = 17.9.34616.47
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3162219D-7729-49C4-849A-9CCD889798DB}"
 	ProjectSection(SolutionItems) = preProject
+		.config\dotnet-tools.json = .config\dotnet-tools.json
+		Contributors.txt = Contributors.txt
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
+		FsCheck Release Notes.md = FsCheck Release Notes.md
+		License.txt = License.txt
+		README.md = README.md
 		appveyor.yml = appveyor.yml
 		build.cmd = build.cmd
 		build.fsx = build.fsx
 		build.sh = build.sh
-		Contributors.txt = Contributors.txt
-		Directory.Build.props = Directory.Build.props
-		Directory.Packages.props = Directory.Packages.props
-		.config\dotnet-tools.json = .config\dotnet-tools.json
-		FsCheck Release Notes.md = FsCheck Release Notes.md
-		License.txt = License.txt
-		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{DA5DD4BB-1953-4614-A5E0-9687C63A7234}"


### PR DESCRIPTION
This pull request extends the dependency requirement for FsCheck.NUnit to also include NUnit 4.

I've taken a stab at updating FsCheck to NUnit 4 (dotnet paket update nunit). The one issue is NUnit 4 no longer supports netstandard2.0, but instead targets net6 (and it seems Paket/FsCheck does not support targeting .NET Framework). Other than that there were no changes needed (i.e. no changes to FsCheckPropertyAttribute.fs).

As others have reported, and I can confirm, just forcing FsCheck.NUnit v2 to use NUnit 4 works.

I thought this approach was the most versatile (and does not break backward compatibility).

Fixes #650, related to #685.  

Sponsored by [Counterpoint Dynamics](https://cpdynamics.co.za/).