### PR TITLE
#684 Task<Property> - Draft

### DIFF
--- a/examples/FsCheck.NUnit.CSharpExamples/Examples.cs
+++ b/examples/FsCheck.NUnit.CSharpExamples/Examples.cs
@@ -52,5 +52,31 @@ namespace FsCheck.NUnit.CSharpExamples
         {
             Assert.Inconclusive("this test is inconclusive");
         }
+
+        // Fails as expected.
+        [Property]
+        public bool Test1(bool b) =>
+            b && !b;
+
+        // Fails as expected.
+        [Property]
+        public Property Test2(bool b) =>
+            Prop.Label(b && !b, "Some label.");
+
+        // Fails as expected.
+        [Property]
+        public Task<bool> Test3(bool b) =>
+            Task.FromResult(b && !b);
+
+        // Passes. I would expect this to fail.
+        [Property]
+        public Task<Property> Test4(bool b) =>
+            Task.FromResult(Prop.Label(b && !b, "Some label."));
+
+        // Passes. I would expect this to fail.
+        [Property]
+        public Task<Property> Test5(bool b) =>
+            Task.FromResult(Prop.ToProperty(b).And(!b));
+
     }
 }

--- a/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
+++ b/examples/FsCheck.NUnit.Examples/PropertyExamples.fs
@@ -7,6 +7,34 @@ open FsCheck.NUnit
 
 [<TestFixture>]
 type NUnitTest() =
+    // Fails as expected.
+    [<Property>]
+    let test1 b =
+        b && not b
+
+    // Fails as expected.
+    [<Property>]
+    let test2 b =
+        (b && not b) |> Prop.label "Some label."
+
+    // Fails as expected.
+    [<Property>]
+    let test3 b = async {
+        return (b && not b)
+    }
+
+    // Passes. I would expect this to fail.
+    [<Property>]
+    let test4 b = async { 
+        return ((b && not b) |> Prop.label "Some label.")
+    }
+
+    // Passes. I would expect this to fail.
+    [<Property>]
+    let test5 b = async {
+        return (b .&. not b)
+    }
+
 
     [<Test>]
     member __.NormalTest() =

--- a/src/FsCheck/FSharp.Prop.fs
+++ b/src/FsCheck/FSharp.Prop.fs
@@ -36,11 +36,7 @@ module Prop =
 
     let private stamp str = 
         let add res = 
-            match res with
-            | ResultContainer.Value r -> { r with Stamp = str :: r.Stamp } |> Value
-            | ResultContainer.Future t -> t.ContinueWith (fun (rt :Threading.Tasks.Task<Result>) -> 
-                let r = rt.Result
-                { r with Stamp = str :: r.Stamp }) |> Future
+            { res with Stamp = str :: res.Stamp }
         Prop.mapResult add
 
     ///Classify test cases. Test cases satisfying the condition are assigned the classification given.
@@ -60,11 +56,7 @@ module Prop =
     [<CompiledName("Label")>]
     let label l : ('Testable -> Property) = 
         let add res = 
-            match res with
-            | ResultContainer.Value r -> { r with Labels = Set.add l r.Labels } |> Value
-            | ResultContainer.Future t -> t.ContinueWith (fun (rt :Threading.Tasks.Task<Result>) -> 
-                let r = rt.Result
-                { r with Labels = Set.add l r.Labels }) |> Future
+            { res with Labels = Set.add l res.Labels }
         Prop.mapResult add
 
     /// Turns a testable type into a property. Testables are unit, boolean, Lazy testables, Gen testables, functions


### PR DESCRIPTION
Hello, 

this draft PR is for discussion regarding #684.

Why not remove ``ResultContainer`` altogether and force Task result on the level where Property is created out of Testable?
Do you see any issues with the approach?