### PR TITLE
Support `Async<'Testable>` & `Task<'Testable>`

### DIFF
--- a/examples/FsCheck.Examples/Examples.fs
+++ b/examples/FsCheck.Examples/Examples.fs
@@ -194,7 +194,7 @@ Check.One(bigSize,fun (s:Simple) -> match s with Leaf2 _ -> false | Void3 -> fal
 
 Check.One(bigSize,fun i -> (-10 < i && i < 0) || (0 < i) && (i < 10 ))
 Check.Quick (fun opt -> match opt with None -> false | Some b  -> b  )
-Check.Quick (fun opt -> match opt with Some n when n<0 -> false | Some n when n >= 0 -> true | _ -> true )
+Check.Quick (fun opt -> match opt with Some n when n < 0 -> false | Some n when n >= 0 -> true | _ -> true )
 
 let prop_RevId' (xs:list<int>) (x:int) = if (xs.Length > 2) && (x >10) then false else true
 Check.Quick prop_RevId'

--- a/examples/FsCheck.NUnit.CSharpExamples/SyncVersusAsyncExamples.cs
+++ b/examples/FsCheck.NUnit.CSharpExamples/SyncVersusAsyncExamples.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using FsCheck.Fluent;
+using NUnit.Framework;
+
+namespace FsCheck.NUnit.CSharpExamples;
+
+public class SyncVersusAsyncExamples
+{
+    [Property]
+    public Property Property_ShouldPass(bool b)
+    {
+        return (b ^ !b).Label("b ^ !b");
+    }
+
+    [Property]
+    public Property Property_ShouldFail(bool b)
+    {
+        return (b && !b).Label("b && !b");
+    }
+
+    [Property]
+    public async Task Task_ShouldPass(bool b)
+    {
+        await DoSomethingAsync();
+        Assert.That(b ^ !b);
+    }
+
+    [Property]
+    public async Task Task_Exception_ShouldFail(bool b)
+    {
+        await DoSomethingAsync();
+        Assert.That(b && !b);
+    }
+
+    [Property]
+    public async Task Task_Cancelled_ShouldFail(bool b)
+    {
+        await Task.Run(() => Assert.That(b ^ !b), new System.Threading.CancellationToken(canceled: true));
+    }
+
+    [Property]
+    public async Task<Property> TaskProperty_ShouldPass(bool b)
+    {
+        await DoSomethingAsync();
+        return (b ^ !b).Label("b ^ !b");
+    }
+
+    [Property]
+    public async Task<Property> TaskProperty_ShouldFail(bool b)
+    {
+        await DoSomethingAsync();
+        return (b && !b).Label("b && !b");
+    }
+
+    private static async Task DoSomethingAsync() => await Task.Yield();
+}

--- a/examples/FsCheck.NUnit.Examples/FsCheck.NUnit.Examples.fsproj
+++ b/examples/FsCheck.NUnit.Examples/FsCheck.NUnit.Examples.fsproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <Content Include="App.config" />
         <Compile Include="PropertyExamples.fs" />
+        <Compile Include="SyncVersusAsyncExamples.fs" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/examples/FsCheck.NUnit.Examples/SyncVersusAsyncExamples.fs
+++ b/examples/FsCheck.NUnit.Examples/SyncVersusAsyncExamples.fs
@@ -1,0 +1,29 @@
+﻿namespace FsCheck.NUnit.Examples
+
+open FsCheck.FSharp
+open FsCheck.NUnit
+
+module SyncVersusAsyncExamples =
+    let private doSomethingAsync () = async { return () }
+
+    [<Property>]
+    let ``Sync - should pass`` b =
+        b = b |> Prop.label "b = b"
+
+    [<Property>]
+    let ``Sync - should fail`` b =
+        b = not b |> Prop.label "b = not b"
+
+    [<Property>]
+    let ``Async - should pass`` b =
+        async {
+            do! doSomethingAsync ()
+            return b = b |> Prop.label "b = b"
+        }
+
+    [<Property>]
+    let ``Async - should fail`` b =
+        async {
+            do! doSomethingAsync ()
+            return b = not b |> Prop.label "b = not b"
+        }

--- a/examples/FsCheck.XUnit.CSharpExamples/SyncVersusAsyncExamples.cs
+++ b/examples/FsCheck.XUnit.CSharpExamples/SyncVersusAsyncExamples.cs
@@ -1,0 +1,57 @@
+﻿using System.Threading.Tasks;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Xunit;
+
+namespace FsCheck.XUnit.CSharpExamples;
+
+public class SyncVersusAsyncExamples
+{
+    [Property]
+    public Property Property_ShouldPass(bool b)
+    {
+        return (b ^ !b).Label("b ^ !b");
+    }
+
+    [Property]
+    public Property Property_ShouldFail(bool b)
+    {
+        return (b && !b).Label("b && !b");
+    }
+
+    [Property]
+    public async Task Task_ShouldPass(bool b)
+    {
+        await DoSomethingAsync();
+        Assert.True(b ^ !b);
+    }
+
+    [Property]
+    public async Task Task_Exception_ShouldFail(bool b)
+    {
+        await DoSomethingAsync();
+        Assert.True(b && !b);
+    }
+
+    [Property]
+    public async Task Task_Cancelled_ShouldFail(bool b)
+    {
+        await Task.Run(() => Assert.True(b ^ !b), new System.Threading.CancellationToken(canceled: true));
+    }
+
+    [Property]
+    public async Task<Property> TaskProperty_ShouldPass(bool b)
+    {
+        await DoSomethingAsync();
+        return (b ^ !b).Label("b ^ !b");
+    }
+
+    [Property]
+    public async Task<Property> TaskProperty_ShouldFail(bool b)
+    {
+        await DoSomethingAsync();
+        return (b && !b).Label("b && !b");
+    }
+
+    private static async Task DoSomethingAsync() => await Task.Yield();
+}

--- a/src/FsCheck/FSharp.Prop.fs
+++ b/src/FsCheck/FSharp.Prop.fs
@@ -67,9 +67,8 @@ module Prop =
                 { r with Labels = Set.add l r.Labels }) |> Future
         Prop.mapResult add
 
-    /// Turns a testable type into a property. Testables are unit, boolean, Lazy testables, Gen testables, functions
-    /// from a type for which a generator is know to a testable, tuples up to 6 tuple containing testables, and lists
-    /// containing testables.
+    /// Turns a testable type into a property. Testables are unit, boolean, Lazy testables, Gen testables,
+    /// Async testables, Task testables, and functions from a type for which a generator is know to a testable.
     [<CompiledName("OfTestable")>]
     let ofTestable (testable:'Testable) =
         property testable

--- a/src/FsCheck/FSharp.Prop.fs
+++ b/src/FsCheck/FSharp.Prop.fs
@@ -67,8 +67,8 @@ module Prop =
                 { r with Labels = Set.add l r.Labels }) |> Future
         Prop.mapResult add
 
-    /// Turns a testable type into a property. Testables are unit, boolean, Lazy testables, Gen testables,
-    /// Async testables, Task testables, and functions from a type for which a generator is know to a testable.
+    /// Turns a testable type into a property. Testables are unit, Boolean, Lazy testables, Gen testables,
+    /// Async testables, Task testables, and functions from a type for which a generator is known to a testable.
     [<CompiledName("OfTestable")>]
     let ofTestable (testable:'Testable) =
         property testable

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -937,3 +937,6 @@ module Arbitrary =
 
         [<Fact>]
         let ``task { return task { return false } }`` () = shouldBeFalsy "task { return task { return false } }" (System.Threading.Tasks.Task.FromResult (Prop.ofTestable (System.Threading.Tasks.Task.FromResult false)))
+
+        [<Fact>]
+        let ``task { return lazy false }`` () = shouldBeFalsy "task { return lazy false }" (System.Threading.Tasks.Task.FromResult (lazy false))

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -826,11 +826,6 @@ module Arbitrary =
         assert (ImmutableDictionary.CreateRange(values) |> shrink |> Seq.forall checkShrink)
         assert (ImmutableSortedDictionary.CreateRange(values) |> shrink |> Seq.forall checkShrink)
 
-    [<Property>]
-    let ``should execute generic-task-valued property`` (value: int) =
-        // Since this doesn't throw, the test should pass and ignore the integer value
-        System.Threading.Tasks.Task.FromResult value
-
     [<Fact>]
     let ``Zip should shrink both values independently``() =
         let shrinkable = Arb.fromGenShrink(Gen.choose(0, 10), fun x -> [| x-1 |] |> Seq.where(fun x -> x >= 0))
@@ -838,3 +833,107 @@ module Arbitrary =
         let zipped = Fluent.Arb.Zip(shrinkable, notShrinkable)
         let shrinks = zipped.Shrinker(struct (10, 10)) |> Seq.toArray
         test <@ shrinks = [| struct (9, 10) |]  @>
+
+    module Truthy =
+        let private shouldBeTruthy description testable =
+            try Check.One (Config.QuickThrowOnFailure, testable) with
+            | exn -> failwith $"'%s{description}' should be truthy. Got: '{exn}'."
+
+        [<Fact>]
+        let ``()`` () = shouldBeTruthy "()" ()
+
+        [<Fact>]
+        let ``true`` () = shouldBeTruthy "true" true
+
+        [<Fact>]
+        let ``Prop.ofTestable ()`` () = shouldBeTruthy "Prop.ofTestable ()" (Prop.ofTestable ())
+
+        [<Fact>]
+        let ``lazy ()`` () = shouldBeTruthy "lazy ()" (lazy ())
+
+        [<Fact>]
+        let ``lazy true`` () = shouldBeTruthy "lazy true" (lazy true)
+
+        [<Fact>]
+        let ``lazy Prop.ofTestable ()`` () = shouldBeTruthy "lazy Prop.ofTestable ()" (lazy Prop.ofTestable ())
+
+        [<Fact>]
+        let ``gen { return () }`` () = shouldBeTruthy "gen { return () }" (gen { return () })
+
+        [<Fact>]
+        let ``gen { return true }`` () = shouldBeTruthy "gen { return true }" (gen { return true })
+
+        [<Fact>]
+        let ``gen { return Prop.ofTestable () }`` () = shouldBeTruthy "gen { return Prop.ofTestable () }" (gen { return Prop.ofTestable () })
+
+        [<Fact>]
+        let ``async { return () }`` () = shouldBeTruthy "async { return () }" (async { return () })
+
+        [<Fact>]
+        let ``async { return true }`` () = shouldBeTruthy "async { return true }" (async { return true })
+
+        [<Fact>]
+        let ``async { return Prop.ofTestable () }`` () = shouldBeTruthy "async { return Prop.ofTestable () }" (async { return Prop.ofTestable () })
+
+        [<Fact>]
+        let ``task { return true }`` () = shouldBeTruthy "task { return true }" (System.Threading.Tasks.Task.FromResult true)
+
+        [<Fact>]
+        let ``task { return () }`` () = shouldBeTruthy "task { return () }" (System.Threading.Tasks.Task.FromResult ())
+
+        [<Fact>]
+        let ``task { return Prop.ofTestable () }`` () = shouldBeTruthy "task { return Prop.ofTestable () }" (System.Threading.Tasks.Task.FromResult (Prop.ofTestable ()))
+
+        [<Fact>]
+        let ``task { return fun b -> b ==> b }`` () = shouldBeTruthy "task { return fun b -> b ==> b }" (System.Threading.Tasks.Task.FromResult (fun b -> b ==> b))
+
+        [<Fact>]
+        let ``task { return task { return true } }`` () = shouldBeTruthy "task { return task { return true } }" (System.Threading.Tasks.Task.FromResult (Prop.ofTestable (System.Threading.Tasks.Task.FromResult true)))
+
+    module Falsy =
+        let private shouldBeFalsy description testable =
+            let exn =
+                try Check.One (Config.QuickThrowOnFailure, testable); None with
+                | exn -> Some exn
+
+            match exn with
+            | None -> failwith $"'%s{description}' should be falsy."
+            | Some exn ->
+                if not (exn.Message.StartsWith "Falsifiable") then
+                    failwith $"Unexpected exception: '{exn}'."
+
+        [<Fact>]
+        let ``false`` () = shouldBeFalsy "false" false
+
+        [<Fact>]
+        let ``Prop.ofTestable false`` () = shouldBeFalsy "Prop.ofTestable false" (Prop.ofTestable false)
+
+        [<Fact>]
+        let ``lazy false`` () = shouldBeFalsy "lazy false" (lazy false)
+
+        [<Fact>]
+        let ``lazy Prop.ofTestable false`` () = shouldBeFalsy "lazy Prop.ofTestable false" (lazy Prop.ofTestable false)
+
+        [<Fact>]
+        let ``gen { return false }`` () = shouldBeFalsy "gen { return false }" (gen { return false })
+
+        [<Fact>]
+        let ``gen { return Prop.ofTestable false }`` () = shouldBeFalsy "gen { return Prop.ofTestable false }" (gen { return Prop.ofTestable false })
+
+        [<Fact>]
+        let ``async { return false }`` () = shouldBeFalsy "async { return false }" (async { return false })
+
+        [<Fact>]
+        let ``async { return Prop.ofTestable false }`` () = shouldBeFalsy "async { return Prop.ofTestable false }" (async { return Prop.ofTestable false })
+
+        [<Fact>]
+        let ``task { return false }`` () = shouldBeFalsy "task { return false }" (System.Threading.Tasks.Task.FromResult false)
+
+        [<Fact>]
+        let ``task { return Prop.ofTestable false }`` () = shouldBeFalsy "task { return Prop.ofTestable false }" (System.Threading.Tasks.Task.FromResult (Prop.ofTestable false))
+
+        [<Fact>]
+        let ``task { return fun b -> b ==> not b }`` () = shouldBeFalsy "task { return fun b -> b ==> not b }" (System.Threading.Tasks.Task.FromResult (fun b -> b ==> not b))
+
+        [<Fact>]
+        let ``task { return task { return false } }`` () = shouldBeFalsy "task { return task { return false } }" (System.Threading.Tasks.Task.FromResult (Prop.ofTestable (System.Threading.Tasks.Task.FromResult false)))

--- a/tests/FsCheck.Test/Property.fs
+++ b/tests/FsCheck.Test/Property.fs
@@ -8,6 +8,7 @@ module Property =
     open FsCheck.FSharp
     open FsCheck.Xunit
     open System
+    open System.Threading
     open System.Threading.Tasks
     open Swensen.Unquote
     
@@ -26,9 +27,13 @@ module Property =
                     | And of SymProp * SymProp
                     | Or of SymProp * SymProp
                     | LazyProp of SymProp
-                    | Tuple2 of SymProp * SymProp
-                    | Tuple3 of SymProp * SymProp * SymProp //and 4,5,6
-                    | List of SymProp list
+                    | Task
+                    | FaultedTask
+                    | CancelledTask
+                    | TaskProp of SymProp
+                    | FaultedTaskProp of SymProp
+                    | CancelledTaskProp of SymProp
+                    | AsyncProp of SymProp
      
     let rec private symPropGen =
         let rec recGen size =
@@ -45,9 +50,13 @@ module Property =
                         ; Gen.map2 (curry And) (subProp) (subProp)
                         ; Gen.map2 (curry Or) (subProp) (subProp)
                         ; Gen.map LazyProp subProp
-                        ; Gen.map2 (curry Tuple2) subProp subProp
-                        ; Gen.map3 (curry2 Tuple3) subProp subProp subProp
-                        ; Gen.map List (Gen.resize 3 <| Gen.nonEmptyListOf subProp)
+                        ; Gen.constant Task
+                        ; Gen.constant FaultedTask
+                        ; Gen.constant CancelledTask
+                        ; Gen.map TaskProp subProp
+                        ; Gen.map FaultedTaskProp subProp
+                        ; Gen.map CancelledTaskProp subProp
+                        ; Gen.map AsyncProp subProp
                         ]
             | _ -> failwith "symPropGen: size must be positive"
         Gen.sized recGen
@@ -67,7 +76,7 @@ module Property =
         | Unit ->   { result with Outcome= Outcome.Passed }
         | Bool true -> { result with Outcome= Outcome.Passed }
         | Bool false -> { result with Outcome= Outcome.Failed (exn "")}
-        | Exception  -> { result with Outcome= Outcome.Failed (InvalidOperationException() :> exn)}
+        | Exception | FaultedTask | FaultedTaskProp _ -> { result with Outcome= Outcome.Failed (InvalidOperationException() :> exn)}
         | ForAll (i,prop) -> determineResult prop |> addArgument i
         | Implies (true,prop) -> determineResult prop
         | Implies (false,_) -> { result with Outcome= Outcome.Rejected }
@@ -78,9 +87,9 @@ module Property =
         | And (prop1, prop2) -> andCombine prop1 prop2
         | Or (prop1, prop2) -> let r1,r2 = determineResult prop1, determineResult prop2 in Result.ResOr(r1, r2)
         | LazyProp prop -> determineResult prop
-        | Tuple2 (prop1,prop2) -> andCombine prop1 prop2
-        | Tuple3 (prop1,prop2,prop3) -> Result.ResAnd (andCombine prop1 prop2, determineResult prop3)
-        | List props -> List.fold (fun st p -> Result.ResAnd (st, determineResult p)) (List.head props |> determineResult) (List.tail props)
+        | Task -> { result with Outcome = Outcome.Passed }
+        | CancelledTask | CancelledTaskProp _ -> { result with Outcome = Outcome.Failed (exn "The Task was canceled.") }
+        | TaskProp prop | AsyncProp prop -> determineResult prop
         
     let rec private toProperty prop =
         match prop with
@@ -94,10 +103,26 @@ module Property =
         | Label (l,prop) -> Prop.label l (toProperty prop)
         | And (prop1,prop2) -> (toProperty prop1) .&. (toProperty prop2)
         | Or (prop1,prop2) -> (toProperty prop1) .|. (toProperty prop2)
-        | LazyProp prop -> toProperty prop
-        | Tuple2 (prop1,prop2) -> (toProperty prop1) .&. (toProperty prop2)
-        | Tuple3 (prop1,prop2,prop3) -> (toProperty prop1) .&. (toProperty prop2) .&. (toProperty prop3)
-        | List props -> List.fold (fun st p -> st .&. toProperty p) (List.head props |> toProperty) (List.tail props)
+        | LazyProp prop -> Prop.ofTestable (lazy toProperty prop)
+        | Task -> Prop.ofTestable Task.CompletedTask
+        | FaultedTask -> Prop.ofTestable (Task.FromException (InvalidOperationException ()))
+        | CancelledTask -> Prop.ofTestable (Task.FromCanceled (CancellationToken (canceled=true)))
+        | FaultedTaskProp Unit -> Prop.ofTestable (Task.FromException<unit> (InvalidOperationException ()))
+        | FaultedTaskProp (Bool _) -> Prop.ofTestable (Task.FromException<bool> (InvalidOperationException ()))
+        | FaultedTaskProp (LazyProp (Bool _)) -> Prop.ofTestable (Task.FromException<Lazy<bool>> (InvalidOperationException ()))
+        | FaultedTaskProp _ -> Prop.ofTestable (Task.FromException<Property> (InvalidOperationException ()))
+        | CancelledTaskProp Unit -> Prop.ofTestable (Task.FromCanceled<unit> (CancellationToken (canceled=true)))
+        | CancelledTaskProp (Bool _) -> Prop.ofTestable (Task.FromCanceled<bool> (CancellationToken (canceled=true)))
+        | CancelledTaskProp (LazyProp (Bool _)) -> Prop.ofTestable (Task.FromCanceled<Lazy<bool>> (CancellationToken (canceled=true)))
+        | CancelledTaskProp _ -> Prop.ofTestable (Task.FromCanceled<Property> (CancellationToken (canceled=true)))
+        | TaskProp Unit -> Prop.ofTestable (Task.FromResult ())
+        | TaskProp (Bool b) -> Prop.ofTestable (Task.FromResult b)
+        | TaskProp (LazyProp prop) -> Prop.ofTestable (Task.FromResult (lazy toProperty prop))
+        | TaskProp prop -> Prop.ofTestable (Task.FromResult (toProperty prop))
+        | AsyncProp Unit -> Prop.ofTestable (async { return () })
+        | AsyncProp (Bool b) -> Prop.ofTestable (async { return b })
+        | AsyncProp (LazyProp prop) -> Prop.ofTestable (async { return lazy toProperty prop })
+        | AsyncProp prop -> Prop.ofTestable (async { return toProperty prop })
     
     let private areSame (r0:Result) (r1:TestResult) =
         let testData =
@@ -125,9 +150,8 @@ module Property =
         | And (prop1,prop2) -> 1 + Math.Max(depth prop1, depth prop2)
         | Or (prop1,prop2) -> 1 + Math.Max(depth prop1, depth prop2)
         | LazyProp prop -> 1 + (depth prop)
-        | Tuple2 (prop1,prop2) -> 1 + Math.Max(depth prop1, depth prop2)
-        | Tuple3 (prop1,prop2,prop3) -> 1 + Math.Max(Math.Max(depth prop1, depth prop2),depth prop3)
-        | List props -> 1 + List.fold (fun a b -> Math.Max(a, depth b)) 0 props
+        | Task | FaultedTask | CancelledTask -> 0
+        | TaskProp prop | AsyncProp prop | FaultedTaskProp prop | CancelledTaskProp prop -> 1 + depth prop
     
     //can not be an anonymous type because of let mutable.
     type private GetResultRunner() =
@@ -152,13 +176,12 @@ module Property =
     let DSL() = 
         Prop.forAll (Arb.fromGen symPropGen) (fun symprop ->
             let expected = determineResult symprop
-            let actual = checkResult (toProperty symprop)
             let resultRunner = GetResultRunner()
             let config = Config.Quick.WithRunner(resultRunner).WithMaxTest(2)
             Check.One(config,toProperty symprop)
             let actual = resultRunner.Result
             areSame expected actual
-            |> Prop.label (sprintf "expected = %A - actual = %A" expected actual)
+            |> Prop.label (sprintf "\nexpected =\n%A\nactual =\n%A" expected actual)
             |> Prop.collect (depth symprop)
         )
 


### PR DESCRIPTION
@kurtschelfthout This is basically just the code from [my comment here](https://github.com/fscheck/FsCheck/issues/684#issuecomment-2558624284). Upon further thought and experimentation, I think it might actually be valid, if not  terribly elegant—but perhaps there is something that I still do not understand and that the tests do not cover. It essentially hinges on whether what I am doing with [`Shrink.getValue` inside of `Gen.promote` (after applying `runner`)](https://github.com/fscheck/FsCheck/blob/441f565d320b51a503e8a3fbdd603b33386a34d7/src/FsCheck/Testable.fs#L125-L143) is valid in all scenarios.

Fixes #684.[^1]

- Add support for `Async<'Testable>` and `Task<'Testable>` as first-class testables.

  That is, `Async<'Testable>` and `Task<'Testable>` are now valid testables for any valid instantiation of `'Testable`, just as `Lazy<'Testable>`, `Gen<'Testable>`, or `'Generatable -> 'Testable` already were.

  ```fsharp
  [<Property>]
  let ``Unit - used to pass, still passes`` () = ()

  [<Property>]
  let ``Task<unit> - used to pass, still passes`` () = task { return () }

  [<Property>]
  let ``Task - used to pass, still passes`` () = task { return () } :> Task

  [<Property>]
  let ``Async<unit> - used to pass, still passes`` () = async { return () }

  [<Property>]
  let ``Property - used to fail, still fails`` b = (b && not b) |> Prop.label "b && not b"

  [<Property>]
  let ``Task<Property> - used to pass, now fails`` b = task { return (b && not b) |> Prop.label "b && not b" }

  [<Property>]
  let ``Async<Property> - used to pass, now fails`` b = async { return (b && not b) |> Prop.label "b && not b" }

  [<Property>]
  let ``Task<Lazy<bool>> - used to pass, now fails`` b = task { return lazy b }

  // Etc.
  ```

[^1]: Note that this is technically a breaking change in that it breaks the example added in #634. An explicit upcast to non-generic `Task` (`… :> Task`) will now be needed for tests involving `Task<'T>` where `'T` is not itself a testable type to pass. This matches the behavior for the unwrapped equivalent:

    ```fsharp
    [<Property>]
    let ``An int is not a testable`` (i : int) = i
    // System.Exception: No instances of class FsCheck.Testable+ITestable`1[T] for type System.Int32
    
    [<Property>]
    let ``An Async<int> is now also not a testable`` (i : int) = async { return i }
    // System.Exception: No instances of class FsCheck.Testable+ITestable`1[T] for type System.Int32
    
    [<Property>]
    let ``A Task<int> is now also not a testable`` (i : int) = task { return i }
    // System.Exception: No instances of class FsCheck.Testable+ITestable`1[T] for type System.Int32
    ```
    
    The behavior originally desired in #633 for `Task<unit>` is, however, kept: an upcast from `Task<unit>` to `Task` is _not_ required, since `unit` is a testable type.