### PR TITLE
Sample code for Expecto in docs compiles with v10.x

### DIFF
--- a/docs/QuickStart.fsx
+++ b/docs/QuickStart.fsx
@@ -111,7 +111,7 @@ Here's a sample:
 open Expecto
 open Expecto.ExpectoFsCheck
 
-let config = { FsCheck.Config.Default with MaxTest = 10000 }
+let config = { FsCheckConfig.defaultConfig with maxTest = 10000 }
 
 let properties =
   testList "FsCheck samples" [
@@ -127,7 +127,7 @@ let properties =
         a * (b + c) = a * b + a * c
   ]
 
-Tests.runTests defaultConfig properties
+runTestsWithCLIArgs [] [||] properties
 ```
 
 ### Integration with xUnit


### PR DESCRIPTION
As I promised commenting on [698](https://github.com/fscheck/FsCheck/issues/698#issuecomment-2687025010), I am going through the current documentation, making sure that readers of docs can follow the instructions, copy paste the code and successfully see it work.

The small PR is about the section:



Here's a sample:
```fsharp
open Expecto
open Expecto.ExpectoFsCheck

let config = { FsCheck.Config.Default with MaxTest = 10000 }

let properties =
  testList "FsCheck samples" [
    testProperty "Addition is commutative" <| fun a b ->
      a + b = b + a
      
    testProperty "Reverse of reverse of a list is the original list" <|
      fun (xs:list<int>) -> List.rev (List.rev xs) = xs

    // you can also override the FsCheck config
    testPropertyWithConfig config "Product is distributive over addition" <|
      fun a b c ->
        a * (b + c) = a * b + a * c
  ]

Tests.runTests defaultConfig properties
```


which apparently does not compile anymore.

The problems are with:

```fsharp
let config = { FsCheck.Config.Default with MaxTest = 10000 }
```

and

```fsharp
Tests.runTests defaultConfig properties
```

which I had to replace respectively with:

```fsharp
let config = { FsCheckConfig.defaultConfig with maxTest = 10000 }
```

and

```fsharp
runTestsWithCLIArgs [] [||] properties
```

The former is related to a breaking change in FsCheck; the latter is Expecto related.

