### PR TITLE
Fix to some minor typos

### DIFF
--- a/docs/Properties.fsx
+++ b/docs/Properties.fsx
@@ -26,7 +26,7 @@ It's very simple to fix any types anyway simply by adding some type annotations.
 
 FsCheck can check properties of various forms - these forms are called testable, 
 and are indicated in the API by a generic type called `'Testable`. A `'Testable` may 
-be a function of any number of parameters that returns bool or unit. In the latter case, 
+be a function of any number of parameters that returns `bool` or `unit`. In the latter case, 
  a test passes if it does not throw. The entry point to create properties is the Prop module.
 
  Like all of FsCheck's API, there are C# counterparts for all of the F# methods described.
@@ -66,7 +66,7 @@ an overall limit on the number of test cases is reached (to avoid looping if the
 never holds). In this case a message such as "Arguments exhausted after 97 tests."
 indicates that 97 test cases satisfying the condition were found, and that the property held in those 97 cases.
 
-Notice that in this case the generated values had to be restricted to int. This is because the generated 
+Notice that in this case the generated values had to be restricted to `int`. This is because the generated 
 values need to be comparable, but this is not reflected in the types. Therefore, without the explicit 
 restriction, FsCheck could generate lists containing different types (subtypes of objects), and these are not mutually comparable.
     
@@ -113,7 +113,7 @@ Check.Quick insertWithArb
 (***include-output:insertWithArb***)
 
 (**
-The first argument of forAll is an IArbitrary instance. Such an instance 
+The first argument of `forAll` is an `IArbitrary` instance. Such an instance 
 encapsulates a test data generator and a shrinker (more on that in [Test Data](TestData.html)).
 By supplying a custom generator, instead of using the default generator 
 for that type, it is possible to control the distribution of test data. In 

--- a/docs/Properties.fsx
+++ b/docs/Properties.fsx
@@ -10,7 +10,7 @@ open System
 # Properties
 
 Properties are expressed as F# function definitions or C# lambdas or methods. 
-Properties are universally quantified over their parameters, so *)
+Properties are universally quantified over their parameters, so: *)
 
 let revRevIsOrig (xs:list<int>) = List.rev(List.rev xs) = xs
 
@@ -35,7 +35,7 @@ be a function of any number of parameters that returns bool or unit. In the latt
 
 Properties may take the form `<condition> ==> <property>`
 
-For example,*)
+For example: *)
 
 (***hide***)
 let rec ordered xs = 
@@ -100,7 +100,7 @@ Check.Quick moreLazy
 
 Properties may take the form `forAll <arbitrary>  (fun <args> -> <property>)`.
 
-For example, *)
+For example: *)
 
 (***define-output:insertWithArb***)
 let orderedList = ArbMap.defaults |> ArbMap.arbitrary<list<int>> |> Arb.mapFilter List.sort ordered
@@ -153,7 +153,7 @@ are then summarized when testing is complete.
 
 A property may take the form `trivial <condition> <property>`
 
-For example,*)
+For example: *)
 
 (***define-output:insertTrivial***)
 let insertTrivial (x:int) xs = 
@@ -174,7 +174,7 @@ trivial test cases in the total is reported:*)
 
 A property may take the form `classify <condition> <string> <property>`
 
-For example,*)
+For example: *)
 
 (***define-output:insertClassify***)
 let insertClassify (x:int) xs = 
@@ -198,7 +198,7 @@ Note that a test case may fall into more than one classification.
 
 A property may take the form `collect <expression> <property>`
 
-For example,*)
+For example: *)
 
 (***define-output: insertCollect***)
 let insertCollect (x:int) xs = 
@@ -247,7 +247,7 @@ In that case, it might be difficult upon failure to know excactly which sub-prop
 That's why you can label sub-properties, and FsCheck shows the labels of the failed subproperties when 
 it finds a counter-example using `Prop.label`.
 
-For example,*)
+For example: *)
 
 (***define-output:complex***)
 let complex (m: int) (n: int) =

--- a/docs/Properties.fsx
+++ b/docs/Properties.fsx
@@ -27,7 +27,7 @@ It's very simple to fix any types anyway simply by adding some type annotations.
 FsCheck can check properties of various forms - these forms are called testable, 
 and are indicated in the API by a generic type called `'Testable`. A `'Testable` may 
 be a function of any number of parameters that returns `bool` or `unit`. In the latter case, 
- a test passes if it does not throw. The entry point to create properties is the Prop module.
+ a test passes if it does not throw. The entry point to create properties is the `Prop` module.
 
  Like all of FsCheck's API, there are C# counterparts for all of the F# methods described.
     

--- a/docs/QuickStart.fsx
+++ b/docs/QuickStart.fsx
@@ -138,7 +138,7 @@ the unit test above so it can be run from xUnit.net:*)
 open global.Xunit
 
 [<Fact>]
-let ``Reverse of reverse of a list is the original list``() =
+let ``Reverse of reverse of a list is the original list`` () =
   let revRevIsOrig (xs:list<int>) = List.rev(List.rev xs) = xs
   Check.QuickThrowOnFailure revRevIsOrig
   
@@ -157,7 +157,7 @@ be written more tersely as follows:*)
 open FsCheck.Xunit
 
 [<Property>]
-let ``Reverse of reverse of a list is the original list ``(xs:list<int>) =
+let ``Reverse of reverse of a list is the original list `` (xs:list<int>) =
   List.rev(List.rev xs) = xs
   
 (** xUnit now shows the test similarly to a regular test, and is able to run it directly.

--- a/docs/QuickStart.fsx
+++ b/docs/QuickStart.fsx
@@ -19,7 +19,7 @@ First install FsCheck, open an fsx file and start with:*)
 
 open FsCheck
 
-(** In C#: To easily experiment, start a new console app to execute the snippets below (the output is written to console
+(** In C#: to easily experiment, start a new console app to execute the snippets below (the output is written to console
 by default). Alternatively, in LinqPad, reference FsCheck.dll and FSharp.Core.dll, open namespace FsCheck, change the language to "C# statements"
 and you should be able to execute most of the snippets as well. 
 

--- a/docs/QuickStart.fsx
+++ b/docs/QuickStart.fsx
@@ -11,7 +11,7 @@
 
 The fastest way to understand how FsCheck works is by writing some *properties* - FsCheck's terminology for a parametrized
 test, or a generative test - and run them using the built-in test runner. Later on, we'll describe how they can be integrated
-with existing test frameworks like NUnit, xUnit.NET or MsTest.
+with existing test frameworks like NUnit, xUnit.net or MsTest.
 
 First install FsCheck, open an fsx file and start with:*)
 
@@ -132,8 +132,8 @@ runTestsWithCLIArgs [] [||] properties
 
 ### Integration with xUnit
 
-Another frequently used runner is xUnit.NET. Here is how to write 
-the unit test above so it can be run from xUnit.NET:*)
+Another frequently used runner is xUnit.net. Here is how to write 
+the unit test above so it can be run from xUnit.net:*)
 
 open global.Xunit
 
@@ -149,9 +149,9 @@ For xUnit, the test looks like any normal test, and the QuickThrowOnFailure ensu
 an exception with the necessary information is raised so xUnit knows the test failed. The output of the test is the same
 as above.
 
-### Using FsCheck with xUnit.NET using the plugin
+### Using FsCheck with xUnit.net using the plugin
 
-xUnit.NET is "blessed" with an FsCheck plugin. To use it, install the FsCheck.Xunit NuGet package. The test above can now
+xUnit.net is "blessed" with an FsCheck plugin. To use it, install the FsCheck.Xunit NuGet package. The test above can now
 be written more tersely as follows:*)
 
 open FsCheck.Xunit

--- a/docs/QuickStart.fsx
+++ b/docs/QuickStart.fsx
@@ -62,7 +62,7 @@ To learn more on how to write properties, see [Properties](Properties.html).
 ## What do I do if a test loops or encounters an error?
 
 In this case we know that the property does not hold, but Check.Quick does not display the counter-example. 
-There is another testing function provided for this situation. Repeat the test using 
+There is another testing function provided for this situation. Repeat the test using:
 <pre>Check.Verbose</pre> or in C# <pre>VerboseCheck()</pre>
 which displays each test case before running the test: the last test case displayed is thus
 the one in which the loop or error arises.

--- a/docs/RunningTests.fsx
+++ b/docs/RunningTests.fsx
@@ -25,8 +25,8 @@ This section describes the various ways in which you can run FsCheck tests:
 It writes the result of tests to standard output, and you can configure the FsCheck runner to throw an exception on test failure
 to signal the failure to whichever test runner you use.
 
-* FsCheck.Xunit integrates FsCheck with xUnit.NET to allow you to specify properties in a terse way. Tests written
-this way look like native xUnit.NET tests, except they can take arguments.
+* FsCheck.Xunit integrates FsCheck with xUnit.net to allow you to specify properties in a terse way. Tests written
+this way look like native xUnit.net tests, except they can take arguments.
 
 * FsCheck.NUnit integrates FsCheck with NUnit to allow you to specify properties in a terse way. Tests written
 this way look like native NUnit tests, except they can take arguments.
@@ -131,11 +131,11 @@ open FsCheck
 open FsCheck.Xunit
 
 (**
-You can now attribute tests with `PropertyAttribute` (a subclass of xUnit.NET's `FactAttribute`). Unlike xUnit.NET's facts, these 
+You can now attribute tests with `PropertyAttribute` (a subclass of xUnit.net's `FactAttribute`). Unlike xUnit.net's facts, these 
 methods can take arguments and should return a property. FsCheck will be used to generate and shrink the arguments based on the
 type and the currently registered generators. 
 
-An FsCheck test fails from xUnit.NET's perspective if it finds a counter-example, or if the arguments are exhausted. It
+An FsCheck test fails from xUnit.net's perspective if it finds a counter-example, or if the arguments are exhausted. It
 passes when FsCheck can execute 100 tests (or whatever the configured number of tests is) succesfully.
 
 The `PropertyAttribute` allows you to customize how FsCheck will run for that

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -21,7 +21,7 @@ This leaves us in the unfortunate position that some documentation is out of dat
 
 The documentation and API docs for 2.x are not easily accessible anymore. The last commit of the 2.x documentation site is [here](https://github.com/fscheck/FsCheck/tree/1458b268b4311f7e4b25871715f1f9b5d58a21b3).
 
-Pleae help fixing this! FsCheck welcoms contributions of all kinds, big or small. See [issues](https://github.com/fscheck/FsCheck/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for inspiration. Feel free to open an issue to highlight specific documentation problems or gaps, even if you're not sure it really is a problem. At worst you'll get an answer to your question.
+Please help fixing this! FsCheck welcoms contributions of all kinds, big or small. See [issues](https://github.com/fscheck/FsCheck/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for inspiration. Feel free to open an issue to highlight specific documentation problems or gaps, even if you're not sure it really is a problem. At worst you'll get an answer to your question.
 
 Documentation
 -------------

--- a/examples/CSharp.DocSnippets/Properties.cs
+++ b/examples/CSharp.DocSnippets/Properties.cs
@@ -7,8 +7,8 @@ using System.Runtime.CompilerServices;
 
 namespace CSharp.DocSnippets
 {
-    public static class Extensions {
-        public static IEnumerable<int> Insert(this IEnumerable<int> cs, int x) {
+    static class Extensions {
+        internal static IEnumerable<int> Insert(this IEnumerable<int> cs, int x) {
             var result = new List<int>(cs);
             foreach (var c in cs) {
                 if (x <= c) {
@@ -20,7 +20,7 @@ namespace CSharp.DocSnippets
             return result;
         }
 
-        public static bool IsOrdered<T>(this IEnumerable<T> source) {
+        internal static bool IsOrdered<T>(this IEnumerable<T> source) {
             //by Jon Skeet
             //I was too lazy to write it myself, and wondered whether a prettier 
             //solution might exist in C# than the one I had in mind.

--- a/examples/CSharp.DocSnippets/Properties.cs
+++ b/examples/CSharp.DocSnippets/Properties.cs
@@ -43,7 +43,7 @@ namespace CSharp.DocSnippets
     class Properties {
 
         //[revRevIsOrig]
-        public static bool RevRevIsOriginal(int[] ts) {
+        static bool RevRevIsOriginal(int[] ts) {
             return ts.Reverse().Reverse().SequenceEqual(ts);
         }
         //[/revRevIsOrig]

--- a/examples/CSharp.DocSnippets/QuickStart.cs
+++ b/examples/CSharp.DocSnippets/QuickStart.cs
@@ -29,7 +29,8 @@ namespace CSharp
 
         //[revRevIsOrigFact]
         [Fact]
-        public void RevRevIsOrig(){
+        void RevRevIsOrig()
+        {
             Prop.ForAll<int[]>(xs => xs.Reverse().Reverse().SequenceEqual(xs))
                 .QuickCheckThrowOnFailure();
         }

--- a/examples/FsCheck.Examples/Examples.fs
+++ b/examples/FsCheck.Examples/Examples.fs
@@ -25,7 +25,7 @@ Check.Quick testEnum
 
 
 //bug: label not printed because of exception. Workaround: use lazy.
-//actually I don't hink this is fixable, as the exception rolls up the stack, so the labelling
+//actually I don't think this is fixable, as the exception rolls up the stack, so the labelling
 //that happens when a property "returns" gets bypassed.
 //this is irritating when using Assert statements from unit testing frameworks though.
 let labelBug (x:int) =

--- a/examples/FsCheck.XUnit.CSharpExamples/ExtensionMethods.cs
+++ b/examples/FsCheck.XUnit.CSharpExamples/ExtensionMethods.cs
@@ -19,7 +19,7 @@ namespace FsCheck.XUnit.CSharpExamples
             return badReverse2.Count > 10 ? badReverse2 : badReverse2.Reverse();
         }
 
-        /// <summary> When the <paramref name="list"/> is accidently sorted, doesn't revert it! </summary>
+        /// <summary> When the <paramref name="list"/> is accidentally sorted, doesn't revert it! </summary>
         public static IEnumerable<TSource> BadReverse3<TSource>(this IEnumerable<TSource> list) where TSource : IEquatable<TSource>
         {
             var copy = list.ToList();


### PR DESCRIPTION
This is a collection of improvements to **very minor** typos I found while reading the documentation:

* Misspelled "please", "think" and "accidently"
* xUnit.net spelled with capital .NET
* Missing colons before introducing code snippets
* Non standard C# indentation of code snippets
* Some code specific words not formatted verbatim
* A couple of unnecessary `public` access modifier.