### PR TITLE
Using Prop.label instead of @|

### DIFF
--- a/docs/Properties.fsx
+++ b/docs/Properties.fsx
@@ -269,7 +269,7 @@ This is useful for displaying intermediate results, for example:*)
 (***define-output:multiply***)
 let multiply (n: int, m: int) =
     let res = n*m
-    sprintf "evidence = %i" res @| (
+    Prop.label (sprintf "evidence = %i" res) (
       Prop.label "div1" (m <> 0 ==> lazy (res / m = n)) .&. 
       Prop.label "div2" (n <> 0 ==> lazy (res / n = m)) .&. 
       Prop.label "lt1"  (res > m) .&. 


### PR DESCRIPTION
0a68217d removed the `@|` operator (the removal was made public with 3.0.0-rc3 on 3 March 2024, with the invite to use `Prop.label` instead).

I found a sample in the documentation still using `@|`. This PR replaces it with `Prop.label`.