### PR TITLE
Sample C# code for Model-base testing

### DIFF
--- a/docs/StatefulTestingNew.fsx
+++ b/docs/StatefulTestingNew.fsx
@@ -63,6 +63,12 @@ let spec =
         member __.Next _ = Gen.elements [ inc; dec ] }
 
 (**
+
+ In C#:
+
+    [lang=csharp,file=../examples/CSharp.DocSnippets/StatefulTesting.cs,key=Specification]
+
+
 Let's break this down a bit. A specification is put together as an object that is a subtype of the abstract class `Machine<'TypeUnderTest,'ModelType>`. 
 What you're actually defining is a state machine which can simultaneously apply operations, or state transitions, to the actual system
 under test (in this case, a simple object) and a model of the system under test.

--- a/docs/StatefulTestingNew.fsx
+++ b/docs/StatefulTestingNew.fsx
@@ -29,11 +29,11 @@ type Counter(?initial:int) =
 
     [lang=csharp,file=../examples/CSharp.DocSnippets/StatefulTesting.cs,key=Counter]
 
-As a model to test this class we can use an int value which is an abstraction of the object's internal state. The
-idea is that each operation on the class (in this case, Inc, Dec and Reset) affects both the model object and the actual object, and 
+As a model to test this class we can use an `int` value which is an abstraction of the object's internal state. The
+idea is that each operation on the class (in this case, `Inc`, `Dec` and `Reset`) affects both the model object and the actual object, and 
 after each such operation, the model and the actual instance should still be equivalent.
 
-With this idea in mind, you can write a specification of the Counter class using an int model as follows:*)
+With this idea in mind, you can write a specification of the `Counter` class using an int model as follows:*)
 
 let spec =
     let inc = 
@@ -91,7 +91,7 @@ calls `Inc()` or `Dec()` on the `Counter` instance, and checks that after that t
 silly, for demonstration purposes) precondition that the value should be strictly greater than 0 - if we run this machine our `Counter` throws if we call `Dec` 
 so when we run this specification we can check that FsCheck does the right thing here (testing the test library, very meta...)
 
-We also override ToString in each `Operation` so that counter-examples can be printed.
+We also override `ToString` in each `Operation` so that counter-examples can be printed.
 
 A specification can be checked as follows:*)
 

--- a/docs/StatefulTestingNew.fsx
+++ b/docs/StatefulTestingNew.fsx
@@ -25,7 +25,10 @@ type Counter(?initial:int) =
     member __.Reset() = n <- 0
     override __.ToString() = sprintf "Counter = %i" n
 
-(**
+(** In C#:
+
+    [lang=csharp,file=../examples/CSharp.DocSnippets/StatefulTesting.cs,key=Counter]
+
 As a model to test this class we can use an int value which is an abstraction of the object's internal state. The
 idea is that each operation on the class (in this case, Inc, Dec and Reset) affects both the model object and the actual object, and 
 after each such operation, the model and the actual instance should still be equivalent.

--- a/examples/CSharp.DocSnippets/StatefulTesting.cs
+++ b/examples/CSharp.DocSnippets/StatefulTesting.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace CSharp.DocSnippets;
+
+public class StatefulTesting
+{
+    //[Counter]
+    class Counter
+    {
+        private int _n;
+
+        internal Counter(int n)
+        {
+            _n = n;
+        }
+
+        internal void Inc()
+        {
+            if (_n <= 3)
+                _n += 1;
+            else
+                _n = -_n + 2;
+        }
+
+        internal void Dec()
+        {
+            if (_n <= 0)
+                throw new InvalidOperationException("Precondition fail");
+
+            _n -= 1;
+        }
+
+        internal void Reset()
+        {
+            _n = 0;
+        }
+
+        public override string ToString() => $"Counter = {_n}";
+    }
+    //[/Counter]
+}

--- a/examples/CSharp.DocSnippets/StatefulTesting.cs
+++ b/examples/CSharp.DocSnippets/StatefulTesting.cs
@@ -1,41 +1,138 @@
-using System;
-
 namespace CSharp.DocSnippets;
+
+using System;
+using System.Collections.Generic;
+using FsCheck;
+using FsCheck.Experimental;
+using FsCheck.Fluent;
+using Microsoft.FSharp.Collections;
+using Xunit;
 
 public class StatefulTesting
 {
     //[Counter]
-    class Counter
+    public class Counter
     {
-        private int _n;
+        internal int N { get; private set; }
 
         internal Counter(int n)
         {
-            _n = n;
+            N = n;
         }
 
         internal void Inc()
         {
-            if (_n <= 3)
-                _n += 1;
+            if (N <= 3)
+                N += 1;
             else
-                _n = -_n + 2;
+                N = -N + 2;
         }
 
         internal void Dec()
         {
-            if (_n <= 0)
+            if (N <= 0)
                 throw new InvalidOperationException("Precondition fail");
 
-            _n -= 1;
+            N -= 1;
         }
 
         internal void Reset()
         {
-            _n = 0;
+            N = 0;
         }
 
-        public override string ToString() => $"Counter = {_n}";
+        public override string ToString() => $"Counter = {N}";
     }
     //[/Counter]
+
+    //[Specification]
+    private class CounterSpec
+    {
+        internal class Inc : Operation<Counter, int>
+        {
+            public override bool Pre(int m)
+            {
+                return m > 0;
+            }
+
+            public override int Run(int m)
+            {
+                return m + 1;
+            }
+
+            public override Property Check(Counter c, int m)
+            {
+                return (m == c.N).Label($"Inc: model = {m}, actual = {c.N}");
+            }
+
+            public override string ToString() => "inc";
+        }
+
+        internal class Dec : Operation<Counter, int>
+        {
+            public override bool Pre(int m)
+            {
+                return m > 0;
+            }
+
+            public override int Run(int m)
+            {
+                return m - 1;
+            }
+
+
+            public override Property Check(Counter c, int m)
+            {
+                c.Dec();
+                return (m == c.N).Label($"Dec: model = {m}, actual = {c.N}");
+            }
+
+            public override string ToString() => "dec";
+        }
+
+        internal class CounterSetup : Setup<Counter, int>
+        {
+            private readonly int _initialValue;
+
+            internal CounterSetup(int initialValue)
+            {
+                _initialValue = initialValue;
+            }
+
+            public override Counter Actual() => new(_initialValue);
+
+            public override int Model() => _initialValue;
+        }
+    }
+
+    public class Specification : Machine<Counter, int>
+    {
+        public Specification(int maxNumberOfCommands) : base(maxNumberOfCommands) { }
+
+        public override Arbitrary<Setup<Counter, int>> Setup =>
+            Arb.From(Gen.Choose(0, 3)
+                .Select<int, Setup<Counter, int>>(i => new CounterSpec.CounterSetup(i)));
+
+        public override TearDown<Counter> TearDown => new DisposeCall<Counter>();
+        
+        public override Gen<Operation<Counter, int>> Next(int _) =>
+            Gen.Elements(new Operation<Counter, int>[]
+            {
+                new CounterSpec.Inc(), 
+                new CounterSpec.Dec()
+            });
+
+        public override IEnumerable<FSharpList<Operation<Counter, int>>> ShrinkOperations(FSharpList<Operation<Counter, int>> operation) => 
+            base.ShrinkOperations(operation);
+    }
+    //[/Specification]
+
+    
+    [Fact]
+    void counter_tested_with_stateful_testing()
+    {
+        var property = new Specification(10).ToProperty();
+
+        Check.QuickThrowOnFailure(property);
+    }
 }


### PR DESCRIPTION
Here's the C# sample code for the documentation of model-based testing.

This fixes #651.

The xUnit test included in `StatefulTesting.cs` fails as expected and shrinks the result, just like its equivalent F# counterpart does:

```
System.Exception: Falsifiable, after 2 tests (7 shrinks) (5300258228397282807,4958061799022127411)

System.Exception
Falsifiable, after 2 tests (7 shrinks) (5300258228397282807,4958061799022127411)
Last step was invoked with size of 3 and seed of (10627190116743403733,17882348317831933203):
Label of failing property: Inc: model = 4, actual = 3
Original:
(3, Setup Counter)
inc -> 4
dec -> 3
inc -> 4
dec -> 3
inc -> 4
dec -> 3
dec -> 2
dec -> 1
inc -> 2
inc -> 3
Nothing
Shrunk:
(3, Setup Counter)
inc -> 4
Nothing
with exception:
System.Exception: Expected true, got false.
```

The PR includes both the C# code in `examples/CSharp.DocSnippets/StatefulTesting.cs` and the reference in the narrative page `docs/StatefulTestingNew.fsx`.