### PR TITLE
XUnit Property attribute respects IAsyncLifetime

### DIFF
--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -234,7 +234,15 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                     let target =
                         let testClass = this.TestMethod.TestClass.Class.ToRuntimeType()
                         if (not (isNull this.TestMethod.TestClass)) && not this.TestMethod.Method.IsStatic then
-                            Some (test.CreateTestClass(testClass, constructorArguments, messageBus, timer, cancellationTokenSource))
+                            let testInstance = test.CreateTestClass(testClass, constructorArguments, messageBus, timer, cancellationTokenSource)
+
+                            match testInstance with
+                            | :? IAsyncLifetime as asyncLifetime -> asyncLifetime.InitializeAsync()
+                            | _ -> Task.CompletedTask
+                            |> ignore
+
+                            Some testInstance
+
                         else None
 
                     timer.Aggregate(fun () -> Check.Method(config, runMethod, ?target=target))

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -224,7 +224,7 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                 | :? IDisposable as d -> d.Dispose()
                 | _ -> ()
 
-        let testExec() =            
+        let testExec() =
             let config = this.Init(outputHelper)
             let timer = ExecutionTimer()
             let result =
@@ -234,15 +234,17 @@ type PropertyTestCase(diagnosticMessageSink:IMessageSink, defaultMethodDisplay:T
                     let target =
                         let testClass = this.TestMethod.TestClass.Class.ToRuntimeType()
                         if (not (isNull this.TestMethod.TestClass)) && not this.TestMethod.Method.IsStatic then
+
                             let testInstance = test.CreateTestClass(testClass, constructorArguments, messageBus, timer, cancellationTokenSource)
 
                             match testInstance with
                             | :? IAsyncLifetime as asyncLifetime -> asyncLifetime.InitializeAsync()
                             | _ -> Task.CompletedTask
-                            |> ignore
+                            |> Async.AwaitTask
+                            |> Async.StartAsTask
+                            |> Task.WaitAll
 
                             Some testInstance
-
                         else None
 
                     timer.Aggregate(fun () -> Check.Method(config, runMethod, ?target=target))

--- a/tests/FsCheck.Test/Fscheck.XUnit/PropertyAttributeTests.fs
+++ b/tests/FsCheck.Test/Fscheck.XUnit/PropertyAttributeTests.fs
@@ -1,8 +1,9 @@
 ﻿namespace Fscheck.Test.FsCheck.XUnit.PropertyAttribute
 
-open FsCheck
+open System.Threading.Tasks
 open FsCheck.FSharp
 open FsCheck.Xunit
+open Xunit
 
 type AttributeLevel =
 | Assembly
@@ -69,3 +70,18 @@ module ``when module has properties attribute`` =
         | _ -> false
 
 
+module ``when type implements IAsyncLifetime`` =
+    type Issue657() =
+
+        let mutable executed = false;
+
+        interface IAsyncLifetime with
+            member _.InitializeAsync() =
+                executed <- true;
+                Task.CompletedTask
+
+            member _.DisposeAsync() = Task.CompletedTask
+
+        [<Property>]
+        member this.``then InitializeAsync() is invoked``() =
+            executed = true

--- a/tests/FsCheck.Test/Fscheck.XUnit/PropertyAttributeTests.fs
+++ b/tests/FsCheck.Test/Fscheck.XUnit/PropertyAttributeTests.fs
@@ -77,11 +77,17 @@ module ``when type implements IAsyncLifetime`` =
 
         interface IAsyncLifetime with
             member _.InitializeAsync() =
-                executed <- true;
-                Task.CompletedTask
+
+                async {
+                    do! Async.Sleep 300
+                    executed <- true
+                    return ()
+                }
+                |> Async.StartAsTask
+                :> Task
 
             member _.DisposeAsync() = Task.CompletedTask
 
-        [<Property>]
+        [<Property(MaxTest = 1)>]
         member this.``then InitializeAsync() is invoked``() =
             executed = true


### PR DESCRIPTION
Here's an attempt to fix #657.

This is my first change to FsCheck code, so I will surely need a good helping hand.

The change is few lines of code:

- When the testInstance is created (in `PropertyAttribute`), it checks whether the test class implements `IAsyncLifetime`.
- In that case, it invokes `InitializeAsync()`

```fsharp
    match testInstance with
    | :? IAsyncLifetime as asyncLifetime -> asyncLifetime.InitializeAsync()
    | _ -> Task.CompletedTask
    |> ignore
```

The PR includes a test, based on the sample code I proposed in https://github.com/fscheck/FsCheck/issues/657#issuecomment-2748538580

Please, notice that `DisposeAsync` is not invoked. Apparently, neither xUnit invokes it. I am not sure if this is the correct behavior, though.