### PR TITLE
Tests for FsCheck.Internals.Common.memoize

### DIFF
--- a/tests/FsCheck.Test/FsCheck.Test.fsproj
+++ b/tests/FsCheck.Test/FsCheck.Test.fsproj
@@ -14,6 +14,7 @@
         <Compile Include="FsCheck.NUnit\PropertyAttributeTests.fs" />
         <Compile Include="Fscheck.XUnit\PropertyAttributeTests.fs" />
         <Compile Include="Helpers.fs" />
+        <Compile Include="Internal.Common.fs" />
         <Compile Include="Random.fs" />
         <Compile Include="TypeClass.fs" />
         <Compile Include="Gen.fs" />

--- a/tests/FsCheck.Test/Helpers.fs
+++ b/tests/FsCheck.Test/Helpers.fs
@@ -5,8 +5,6 @@ do()
 
 module Helpers = 
 
-    open System
-    open FsCheck
     open FsCheck.FSharp
 
     let sample n = Gen.sampleWithSize 1000 n
@@ -16,14 +14,3 @@ module Helpers =
     let isIn l elem = List.exists ((=) elem) l
 
     let assertTrue pred = if not pred then failwith "assertion failure"
-
-    open global.Xunit
-    open System.Threading
-    open System.Threading.Tasks
-
-    [<Fact>]
-    let ``memoize is thread-safe``() =
-        let f (a: int) = Thread.Sleep 100; a
-        let memoized = Internals.Common.memoize f
-        Array.init 100 (fun _ -> Action(fun _ -> memoized 1 |> ignore))
-        |> Parallel.Invoke

--- a/tests/FsCheck.Test/Internal.Common.fs
+++ b/tests/FsCheck.Test/Internal.Common.fs
@@ -1,0 +1,31 @@
+module FsCheck.Test.Internals
+
+open FsCheck
+open FsCheck.Xunit
+open Swensen.Unquote
+
+[<Property>]
+let ``memoized functions return the same value of the original function`` (f: string -> int, a: string) =
+
+    let memoized = FsCheck.Internals.Common.memoize f
+
+    let result = f a
+    let resultFromMemoized = memoized a
+
+    test <@ resultFromMemoized = result @>
+
+[<Property>]
+let ``memoized functions are invoked only once`` (f: string -> int, a: string, times: PositiveInt) =
+    let mutable numberOfInvocations = 0
+
+    let countAndInvoke a =
+        numberOfInvocations <- numberOfInvocations + 1
+        f a
+
+    let memoized = FsCheck.Internals.Common.memoize countAndInvoke
+
+    [ 0..times.Get ]
+    |> Seq.iter (fun _ -> memoized a |> ignore)
+
+
+    test <@ numberOfInvocations = 1 @>


### PR DESCRIPTION
Following the discussion in #704, here are 2 tests for the function `FsCheck.Internals.Common.memoize`.

The tests are in a new `Internal.Common.fs` file, named after the production file hosting the original `memoize` function.

The tests themselves are properties. Should you prefer having them based on xUnit, I'll be happy to turn them into Facts.