### PR TITLE
Support C# struct records

### DIFF
--- a/tests/FsCheck.Test.CSharp/FsCheck.Test.CSharp.csproj
+++ b/tests/FsCheck.Test.CSharp/FsCheck.Test.CSharp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>9</LangVersion>
+        <LangVersion>10</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tests/FsCheck.Test.CSharp/Records.cs
+++ b/tests/FsCheck.Test.CSharp/Records.cs
@@ -26,4 +26,22 @@ namespace FsCheck.Test.CSharp
     {
         public int B { get; init; }
     }
+
+    public readonly record struct ReadOnlyStructPositionalRecord(byte Red, byte Green, byte Blue);
+
+    public readonly record struct ReadOnlyStructInitOnlyRecord
+    {
+        public byte Red { get; init; }
+        public byte Green { get; init; }
+        public byte Blue { get; init; }
+    }
+
+    public record struct MutableStructPositionalRecord(byte Red, byte Green, byte Blue);
+
+    public record struct MutableStructRecord
+    {
+        public byte Red { get; set; }
+        public byte Green { get; set; }
+        public byte Blue { get; set; }
+    }
 }

--- a/tests/FsCheck.Test/Arbitrary.fs
+++ b/tests/FsCheck.Test/Arbitrary.fs
@@ -763,6 +763,12 @@ module Arbitrary =
         let mixed = generate<CSharp.CtorAndProps> |> sample 10
         test <@ mixed |> Seq.exists(fun p -> p.B <> 0) @>
 
+    [<Fact>]
+    let ``should derive generator for csharp struct record types`` () =
+        generate<CSharp.ReadOnlyStructPositionalRecord> |> sample 10 |> ignore
+        generate<CSharp.ReadOnlyStructInitOnlyRecord> |> sample 10 |> ignore
+        generate<CSharp.MutableStructPositionalRecord> |> sample 10 |> ignore
+        generate<CSharp.MutableStructRecord> |> sample 10 |> ignore
 
     [<Property>]
     let ``Derived generator for c# record types shrinks - RgbColor`` (value: CSharp.RgbColor) =


### PR DESCRIPTION
Fixes #708.

- Add support for C# struct records ([`record struct`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/record-structs)).
  - Immutable (`readonly record struct`):
    - Positional
    - Non-positional
  - Mutable (`record struct`):
    - Positional
    - Non-positional

(You can't write C# struct records with a mixture of positional and non-positional properties, to my knowledge.)