### PR TITLE
Add replay hint to failure message

### DIFF
--- a/src/FsCheck/Runner.fs
+++ b/src/FsCheck/Runner.fs
@@ -499,9 +499,12 @@ module Runner =
         | 1 -> sprintf "Label of failing property: %s%s" (labelsToString l) newline
         | _ -> sprintf "Labels of failing property (one or more is failing):%s%s%s" newline (labelsToString l) newline
 
-    let onFailureToString name data originalArgs args usedSeed lastSeed lastSize =
-        sprintf "%sFalsifiable, after %i test%s (%i shrink%s) (%A)%sLast step was invoked with size of %i and seed of (%A):%s" 
-                name data.NumberOfTests (pluralize data.NumberOfTests) data.NumberOfShrinks (pluralize data.NumberOfShrinks) usedSeed newline lastSize lastSeed newline
+    let onFailureToString name data originalArgs args usedSeed (lastSeed:Rnd) lastSize =
+        let replayHint =
+            if data.NumberOfTests > 1 then $".%s{newline}Replay directly at failing step with (%d{lastSeed.Seed},%d{lastSeed.Gamma},%d{lastSize})."
+            else ":"
+
+        $"%s{name}Falsifiable, after %i{data.NumberOfTests} test%s{pluralize data.NumberOfTests} (%i{data.NumberOfShrinks} shrink%s{pluralize data.NumberOfShrinks}) (%A{usedSeed}). %s{newline}Last step was invoked with size of %i{lastSize} and seed of (%A{lastSeed})%s{replayHint}%s{newline}"
             + maybePrintLabels data.Labels
             + sprintf "Original:%s%s%s" newline (argumentsToString originalArgs) newline
             + if (data.NumberOfShrinks > 0 ) then sprintf "Shrunk:%s%s%s" newline (argumentsToString args) newline else ""


### PR DESCRIPTION
Related to https://github.com/fscheck/FsCheck/issues/696.

- Add a replay hint to the failure message when a test fails after more than 1 test. Enables easy copy-pasting for use like https://github.com/fscheck/FsCheck/issues/696#issuecomment-2610886817.

The new hint is only shown if the test fails after more than 1 test; otherwise, the failure message remains the same.

I am open to wording or formatting suggestions if you think it could be improved.

#### Before

```stderr
Falsifiable, after 2 tests (0 shrinks) (16007481833498190592,10453566836947007795).
Last step was invoked with size of 3 and seed of (10777961331788138723,17477835647268427641):
```

#### After

```stderr
Falsifiable, after 2 tests (0 shrinks) (16007481833498190592,10453566836947007795).
Last step was invoked with size of 3 and seed of (10777961331788138723,17477835647268427641).
Replay directly at failing step with (10777961331788138723,17477835647268427641,3).
```