### PR TITLE
Embed Untracked Sources

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Copyright>Copyright 2008-2024</Copyright>
     <Authors>Kurt Schelfthout and contributors</Authors>
     <PackageTags>F# fsharp test random</PackageTags>


### PR DESCRIPTION
Set `EmbedUntrackedSources=true` so that compiler-generated files are included.

I noticed a warning when looking at the package in [NuGet Package Explorer](https://nuget.info/packages/FsCheck/3.3.2):

<img width="542" height="218" alt="image" src="https://github.com/user-attachments/assets/418b587e-e4b2-49e1-b839-cc4b18eef9f0" />

I'm not sure why the two errors are there as `ContinuousIntegrationBuild` and `Deterministic` are both set to `true`:

https://github.com/fscheck/FsCheck/blob/7df8a3c8ac35b3ef1213033fd63d1578dada7335/Directory.Build.props#L9

https://github.com/fscheck/FsCheck/blob/7df8a3c8ac35b3ef1213033fd63d1578dada7335/Directory.Build.props#L5-L7
