### PR TITLE
Update fsdocs tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fsharp.formatting.commandtool": {
-      "version": "9.0.4",
+    "fsdocs-tool": {
+      "version": "21.0.0",
       "commands": [
         "fsdocs"
       ]

--- a/build.fsx
+++ b/build.fsx
@@ -371,7 +371,6 @@ let fsdocParameters =
 
 let fsdocProperties = [
   "Configuration=Release"
-  "TargetFramework=netstandard2.0"
 ]
 
 type HaveGeneratedDocs = HaveGeneratedDocs
@@ -381,7 +380,6 @@ let docs (_ : HaveBuilt) : HaveGeneratedDocs =
 
     [
         "fsdocs" ; "build" ; "--strict" ; "--eval" ; "--clean"
-        "--projects" ; "src/FsCheck/FsCheck.fsproj"
         "--properties" ; yield! fsdocProperties
         "--parameters" ; yield! fsdocParameters
     ]

--- a/docs/RunningTests.fsx
+++ b/docs/RunningTests.fsx
@@ -4,7 +4,7 @@
 (*** hide ***)
 #I @"../src/FsCheck/bin/Release/netstandard2.0"
 #I @"../src/FsCheck.Xunit/bin/Release/netstandard2.0"
-#I @"../src/FsCheck.NUnit/bin/Release/netstandard2.0"
+#I @"../src/FsCheck.NUnit/bin/Release/net6.0"
 #r @"nuget: xunit.core"
 #r @"nuget: NUnit"
 #r "FsCheck"
@@ -13,6 +13,7 @@
 
 open FsCheck
 open System
+open FsCheck.FSharp
 
 (**
 # Running tests

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -26,6 +26,10 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.css" />
     <!-- END SEARCH BOX: this adds support for the search box -->
 
+    <style>
+        .fsdocs-tip { white-space: pre-line; }
+    </style>
+
 </head>
 
 <body>
@@ -73,7 +77,7 @@
     </nav>
     <div class="container">
         <div class="masthead">
-            <h3 class="muted"><a href="{{fsdocs-collection-name-link}}">{{fsdocs-collection-name}}</a></h3>
+            <h3 class="muted"><a href="{{fsdocs-package-project-url}}">{{fsdocs-collection-name}}</a></h3>
         </div>
         <hr />
         <div class="container" id="fsdocs-content">


### PR DESCRIPTION
Hello, 

This should fix #721.

Summary of changes: 
-  use "fsdocs-tool" instead of deprecated "fsharp.formatting.commandtool"
-  generate reference documentation for "FsCheck.Xunit" and "FsCheck.NUnit", not just "FsCheck" itself
- update references in "RunningTests.fsx"
- "template.html" : "fsdocs-collection-name-link" is no longer supported, so use "fsdocs-package-project-url" instead
- "template.html" : add additional style for tooltips. Now "FSharp.Formatting" is generating multi-line tooltips without inserting `<br />` tag between lines.  As a result, tooltips that describe types with multiple members are hard to read. Had to fix this using CSS.