### PR TITLE
Fix the "Useful methods" section in the TestData docs

### DIFF
--- a/docs/TestData.fsx
+++ b/docs/TestData.fsx
@@ -634,11 +634,11 @@ However, there are some important things to notice that are listed here to avoid
     
 ## Useful methods on the Arb and ArbMap module
 
-- `ArbMap.arbitrary<'a> arbMap` returns the Arbitrary instance in `arbMap` for the given type 'a
 - `Arb.fromGen` makes a new Arbitrary instance from just a given generator - the shrinker return the empty sequence
 - `Arb.fromGenShrink` make a new Arbitrary instance from a given generator and shrinker. This is equivalent to implementing Arbitrary yourself, but may be shorter.
-- `ArbMap.generate<'a> arbMap` returns the generator of the Arbitrary instance in `arbMap` for the given type 'a
 - `Arb.convert` given conversion functions to ('a ->'b) and from ('b ->'a), converts an Arbitrary<'a> instance to an Arbitrary<'b>
 - `Arb.filter` filters the generator and shrinker for a given Arbitrary instance to contain only those values that match with the given filter function
 - `Arb.mapFilter` maps the generator and filter the shrinkers for a given Arbitrary instance. Mapping the generator is sometimes faster, e.g. for a PositiveInt it is faster to take the absolute value than to filter the negative values.
+- `ArbMap.arbitrary<'a> arbMap` returns the Arbitrary instance in `arbMap` for the given type 'a
+- `ArbMap.generate<'a> arbMap` returns the generator of the Arbitrary instance in `arbMap` for the given type 'a
 - `ArbMap.defaults` is a map that provides access to all the default Arbitrary instances as they are shipped by FsCheck by default. This is useful when you override a default generator - typically this is because you want to filter certain values from it, and then you need to be able to refer to the default generator in your overriding generator.*)

--- a/docs/TestData.fsx
+++ b/docs/TestData.fsx
@@ -632,14 +632,14 @@ However, there are some important things to notice that are listed here to avoid
 - The same thing with the default DoNotSize generators of the number-like types except Decimal.
 - Most of the default generators of the collection types are just "wrappers" around the F# list. Thus, you can assume that they are generated and shrinked the same way.
     
-## Useful methods on the Arb module
+## Useful methods on the Arb and ArbMap module
 
-- `Arb.from<'a>` returns the registered Arbitrary instance for the given type 'a
+- `ArbMap.arbitrary<'a> arbMap` returns the Arbitrary instance in `arbMap` for the given type 'a
 - `Arb.fromGen` makes a new Arbitrary instance from just a given generator - the shrinker return the empty sequence
 - `Arb.fromGenShrink` make a new Arbitrary instance from a given generator and shrinker. This is equivalent to implementing Arbitrary yourself, but may be shorter.
-- `Arb.generate<'a>` returns the generator of the registered Arbitrary instance for the given type 'a
+- `ArbMap.generate<'a> arbMap` returns the generator of the Arbitrary instance in `arbMap` for the given type 'a
 - `Arb.shrink` return the immediate shrinks of the registered Arbitrary instance for the given value
 - `Arb.convert` given conversion functions to ('a ->'b) and from ('b ->'a), converts an Arbitrary<'a> instance to an Arbitrary<'b>
 - `Arb.filter` filters the generator and shrinker for a given Arbitrary instance to contain only those values that match with the given filter function
 - `Arb.mapFilter` maps the generator and filter the shrinkers for a given Arbitrary instance. Mapping the generator is sometimes faster, e.g. for a PositiveInt it is faster to take the absolute value than to filter the negative values.
-- `Arb.Default` is a type that contains all the default Arbitrary instances as they are shipped and registerd by FsCheck by default. This is useful when you override a default generator - typically this is because you want to filter certain values from it, and then you need to be able to refer to the default generator in your overriding generator.*)
+- `ArbMap.defaults` is a map that provides access to all the default Arbitrary instances as they are shipped by FsCheck by default. This is useful when you override a default generator - typically this is because you want to filter certain values from it, and then you need to be able to refer to the default generator in your overriding generator.*)

--- a/docs/TestData.fsx
+++ b/docs/TestData.fsx
@@ -638,7 +638,6 @@ However, there are some important things to notice that are listed here to avoid
 - `Arb.fromGen` makes a new Arbitrary instance from just a given generator - the shrinker return the empty sequence
 - `Arb.fromGenShrink` make a new Arbitrary instance from a given generator and shrinker. This is equivalent to implementing Arbitrary yourself, but may be shorter.
 - `ArbMap.generate<'a> arbMap` returns the generator of the Arbitrary instance in `arbMap` for the given type 'a
-- `Arb.shrink` return the immediate shrinks of the registered Arbitrary instance for the given value
 - `Arb.convert` given conversion functions to ('a ->'b) and from ('b ->'a), converts an Arbitrary<'a> instance to an Arbitrary<'b>
 - `Arb.filter` filters the generator and shrinker for a given Arbitrary instance to contain only those values that match with the given filter function
 - `Arb.mapFilter` maps the generator and filter the shrinkers for a given Arbitrary instance. Mapping the generator is sometimes faster, e.g. for a PositiveInt it is faster to take the absolute value than to filter the negative values.


### PR DESCRIPTION
I remember this confusing me the first time that I used FsCheck.

All other references to `Arb.from<'a>` and `Arb.generate<'a>` on the [Test Data](https://fscheck.github.io/FsCheck//TestData.html) page were already updated  in 0e011f3461d42217c3d2afb4e7d846e4f5411ddc. I looked through the rest of the page as well, and I couldn't find anything else that hasn't been updated to v3 yet.